### PR TITLE
#21/bug: Fix Checkbox hover styles

### DIFF
--- a/src/components/Checkbox/CheckboxWrapper.js
+++ b/src/components/Checkbox/CheckboxWrapper.js
@@ -63,19 +63,19 @@ const CheckboxWrapper = styled.div`
 
   > input:checked + label:hover {
     ::before {
-      border-color: ${colors.gray};
+      border-color: transparent;
       background: ${uiColors('primary.light')};
     }
 
     ::after {
-      border-color: ${colors.white};
+      border-color: ${uiColors('primary.main')};
     }
   }
 
   > input:not(:checked) + label:hover {
     ::before {
       border: 1px solid ${uiColors('primary.main')};
-      background-color: transparent;
+      background-color: ${uiColors('primary.light')};
     }
 
     ::after {


### PR DESCRIPTION
## OVERVIEW

fix: Update Checkbox colors when hovering to match specs.

## WHERE SHOULD THE REVIEWER START?

`/src/components/Checkbox/CheckboxWrapper.js`

## HOW CAN THIS BE MANUALLY TESTED?

`yarn styleguide`
Check the styles for the Checkbox when hovering over checked/non-checked checkbox.
