### PR TITLE
#32/change/Change Tooltip to use secondary color

### DIFF
--- a/src/components/Tooltip/TooltipWrapper.js
+++ b/src/components/Tooltip/TooltipWrapper.js
@@ -1,66 +1,38 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import colors from 'config/colors';
-import { fontSizes } from 'utils';
+import { fontSizes, uiColors } from 'utils';
+
+const tipsVertical = keyframes`
+  to {
+    opacity: 0.9;
+    transform: translate(-50%, 0);
+  }
+`;
+
+const tipsHorizontal = keyframes`
+  to {
+    opacity: 0.9;
+    transform: translate(0, -50%);
+  }
+`;
+
+const tipsDiagonalRight = keyframes`
+  to {
+    opacity: 0.9;
+    transform: translate(-1em, 0);
+  }
+`;
+
+const tipsDiagonalLeft = keyframes`
+  to {
+    opacity: 0.9;
+    transform: translate(1em, 0);
+  }
+`;
 
 const TooltipWrapper = styled.div`
-  color: ${colors.fontDarkGray};
+  color: ${uiColors('text.main')};
   cursor: pointer;
-
-  @-webkit-keyframes tips-vert {
-    to {
-      opacity: 0.9;
-      transform: translate(-50%, 0);
-    }
-  }
-
-  @keyframes tips-vert {
-    to {
-      opacity: 0.9;
-      transform: translate(-50%, 0);
-    }
-  }
-
-  @-webkit-keyframes tips-horz {
-    to {
-      opacity: 0.9;
-      transform: translate(0, -50%);
-    }
-  }
-
-  @keyframes tips-horz {
-    to {
-      opacity: 0.9;
-      transform: translate(0, -50%);
-    }
-  }
-
-  @-webkit-keyframes tips-diag-right {
-    to {
-      opacity: 0.9;
-      transform: translate(-1em, 0);
-    }
-  }
-
-  @keyframes tips-diag-right {
-    to {
-      opacity: 0.9;
-      transform: translate(-1em, 0);
-    }
-  }
-
-  @-webkit-keyframes tips-diag-left {
-    to {
-      opacity: 0.9;
-      transform: translate(1em, 0);
-    }
-  }
-
-  @keyframes tips-diag-left {
-    to {
-      opacity: 0.9;
-      transform: translate(1em, 0);
-    }
-  }
 
   [tooltip] {
     position: relative;
@@ -95,7 +67,7 @@ const TooltipWrapper = styled.div`
     padding: 1ch 1.5ch;
     border-radius: 0.3em;
     box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);
-    background: ${colors.navy};
+    background: ${uiColors('secondary.main')};
     color: ${colors.white};
     z-index: 1000;
     opacity: 0.8;
@@ -110,7 +82,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow^='up']::before {
     bottom: 100%;
     border-bottom-width: 0;
-    border-top-color: ${colors.navy};
+    border-top-color: ${uiColors('secondary.main')};
   }
 
   [tooltip]:not([flow])::after,
@@ -129,7 +101,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow^='down']::before {
     top: 100%;
     border-top-width: 0;
-    border-bottom-color: ${colors.navy};
+    border-bottom-color: ${uiColors('secondary.main')};
   }
 
   [tooltip][flow^='down']::after {
@@ -166,7 +138,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow='left']::before {
     top: 50%;
     border-right-width: 0;
-    border-left-color: ${colors.navy};
+    border-left-color: ${uiColors('secondary.main')};
     left: -5px;
     transform: translate(0.5em, -50%);
   }
@@ -180,7 +152,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow='right']::before {
     top: 50%;
     border-left-width: 0;
-    border-right-color: ${colors.navy};
+    border-right-color: ${uiColors('secondary.main')};
     right: -5px;
     transform: translate(-0.5em, -50%);
   }
@@ -197,22 +169,22 @@ const TooltipWrapper = styled.div`
   [tooltip][flow^='up']:hover::after,
   [tooltip][flow^='down']:hover::before,
   [tooltip][flow^='down']:hover::after {
-    animation: tips-vert 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
+    animation: ${tipsVertical} 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
   }
 
   [tooltip][flow$='-right']:hover::after {
-    animation: tips-diag-right 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
+    animation: ${tipsDiagonalRight} 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
   }
 
   [tooltip][flow$='-left']:hover::after {
-    animation: tips-diag-left 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
+    animation: ${tipsDiagonalLeft} 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
   }
 
   [tooltip][flow='left']:hover::before,
   [tooltip][flow='left']:hover::after,
   [tooltip][flow='right']:hover::before,
   [tooltip][flow='right']:hover::after {
-    animation: tips-horz 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
+    animation: ${tipsHorizontal} 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;
   }
 
   [tooltip='']::after,


### PR DESCRIPTION
change: Replace inline browser-specific `keyframes` with styled keyframes.

* Update Tooltip to use secondary theme color instead of hardcoded.

## OVERVIEW

_Give a brief description of what this PR does._

## WHERE SHOULD THE REVIEWER START?

_e.g. `/lib/elements/SomeComponent.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_List steps to test this locally._

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master

## GIF

_Share a [fun GIF](https://giphy.com) to say thanks to your reviewer:_

![](https://media.giphy.com/media/xTiTnfkt9wCx4fuWhW/giphy.gif)
