### PR TITLE
#49/improve/Tooltip optional color prop

### DIFF
--- a/src/components/Tooltip/Readme.md
+++ b/src/components/Tooltip/Readme.md
@@ -30,4 +30,8 @@ function Page(props) {
 <Tooltip placement="left" dataTip="hello world on the left">
   Hover me!
 </Tooltip>
+
+<Tooltip color="#0da" placement="down" dataTip="custom color tooltip">
+  Hover me!
+</Tooltip>
 ```

--- a/src/components/Tooltip/TooltipWrapper.js
+++ b/src/components/Tooltip/TooltipWrapper.js
@@ -1,4 +1,5 @@
 import styled, { keyframes } from 'styled-components';
+import { ifProp, prop } from 'styled-tools';
 import colors from 'config/colors';
 import { fontSizes, uiColors } from 'utils';
 
@@ -67,7 +68,7 @@ const TooltipWrapper = styled.div`
     padding: 1ch 1.5ch;
     border-radius: 0.3em;
     box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);
-    background: ${uiColors('secondary.main')};
+    background: ${ifProp('color', prop('color'), uiColors('secondary.main'))};
     color: ${colors.white};
     z-index: 1000;
     opacity: 0.8;
@@ -82,7 +83,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow^='up']::before {
     bottom: 100%;
     border-bottom-width: 0;
-    border-top-color: ${uiColors('secondary.main')};
+    border-top-color: ${ifProp('color', prop('color'), uiColors('secondary.main'))};
   }
 
   [tooltip]:not([flow])::after,
@@ -101,7 +102,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow^='down']::before {
     top: 100%;
     border-top-width: 0;
-    border-bottom-color: ${uiColors('secondary.main')};
+    border-bottom-color: ${ifProp('color', prop('color'), uiColors('secondary.main'))};
   }
 
   [tooltip][flow^='down']::after {
@@ -138,7 +139,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow='left']::before {
     top: 50%;
     border-right-width: 0;
-    border-left-color: ${uiColors('secondary.main')};
+    border-left-color: ${ifProp('color', prop('color'), uiColors('secondary.main'))};
     left: -5px;
     transform: translate(0.5em, -50%);
   }
@@ -152,7 +153,7 @@ const TooltipWrapper = styled.div`
   [tooltip][flow='right']::before {
     top: 50%;
     border-left-width: 0;
-    border-right-color: ${uiColors('secondary.main')};
+    border-right-color: ${ifProp('color', prop('color'), uiColors('secondary.main'))};
     right: -5px;
     transform: translate(-0.5em, -50%);
   }

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -6,14 +6,20 @@ type Props = {
   placement: string,
   dataTip: string,
   children: Node,
+  /** Defaults to theme secondary color if no value is passed */
+  color?: string,
 };
 
-const Tooltip = ({ placement, dataTip, children }: Props) => (
-  <TooltipWrapper>
+const Tooltip = ({ placement, dataTip, children, color }: Props) => (
+  <TooltipWrapper color={color}>
     <span tooltip={dataTip} flow={placement}>
       {children}
     </span>
   </TooltipWrapper>
 );
+
+Tooltip.defaultProps = {
+  color: null,
+};
 
 export default Tooltip;


### PR DESCRIPTION
## OVERVIEW

Adds an optional `color` prop to the Tooltip which allows devs to override the default theme value.

## WHERE SHOULD THE REVIEWER START?

`src/components/Tooltip/index.js`

## HOW CAN THIS BE MANUALLY TESTED?

Styleguide demo
