### PR TITLE
 #50/improve/Pass the className prop down in functional/class components

### DIFF
--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -9,17 +9,23 @@ type Props = {
   name: ?string,
   checked: boolean,
   onChange: (checked: boolean) => any,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
-const Checkbox = ({ label, id, onChange, ...rest }: Props) => {
+const Checkbox = ({ label, id, onChange, className, ...rest }: Props) => {
   const onCheckboxChange = (e: SyntheticEvent<HTMLInputElement>): any => onChange(e.target.checked);
 
   return (
-    <CheckboxWrapper>
+    <CheckboxWrapper className={className}>
       <input type="checkbox" id={id} onChange={onCheckboxChange} {...rest} />
       <Label htmlFor={id}>{label}</Label>
     </CheckboxWrapper>
   );
+};
+
+Checkbox.defaultProps = {
+  className: '',
 };
 
 export default Checkbox;

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -10,6 +10,8 @@ import MenuWithLogo from './MenuWithLogo';
 type Props = {
   children: Node,
   logo: ?Element<*> | ?string,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
 type State = {
@@ -19,6 +21,10 @@ type State = {
 class Navbar extends Component<Props, State> {
   static MenuItem: Element<typeof MenuItem>;
 
+  static defaultProps: {
+    className: string,
+  };
+
   state = {
     open: false,
   };
@@ -26,16 +32,20 @@ class Navbar extends Component<Props, State> {
   toggleOpen = () => this.setState(({ open }) => ({ open: !open }));
 
   render() {
-    const { children, logo } = this.props;
+    const { children, logo, className } = this.props;
     const { open } = this.state;
     return (
-      <NavbarContainer open={open} onClick={this.toggleOpen}>
+      <NavbarContainer className={className} open={open} onClick={this.toggleOpen}>
         <MenuWithLogo logo={logo}>{children}</MenuWithLogo>
         <Arrow open={open} />
       </NavbarContainer>
     );
   }
 }
+
+Navbar.defaultProps = {
+  className: '',
+};
 
 Navbar.MenuItem = MenuItem;
 

--- a/src/components/Note/index.js
+++ b/src/components/Note/index.js
@@ -9,14 +9,20 @@ type Props = {
   text: string,
   icon: string,
   type: NoteType,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
-const Note = ({ type, title, text, icon }: Props) => (
-  <NoteWrapper type={type}>
+const Note = ({ type, title, text, icon, className }: Props) => (
+  <NoteWrapper type={type} className={className}>
     <i className={`ipic_${icon}`} />
     <strong>{title}</strong>
     {text}
   </NoteWrapper>
 );
+
+Note.defaultProps = {
+  className: '',
+};
 
 export default Note;

--- a/src/components/Radio/index.js
+++ b/src/components/Radio/index.js
@@ -9,16 +9,22 @@ type Props = {
   name: ?string,
   checked: boolean,
   onChange: (checked: boolean) => any,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
-const Radio = ({ label, id, checked, onChange, ...rest }: Props) => {
+const Radio = ({ label, id, checked, onChange, className, ...rest }: Props) => {
   const onRadioChange = (e: SyntheticEvent<HTMLInputElement>): any => onChange(e.target.checked);
   return (
-    <RadioWrapper>
+    <RadioWrapper className={className}>
       <input type="radio" id={id} checked={checked} onChange={onRadioChange} {...rest} />
       <Label htmlFor={id}>{label}</Label>
     </RadioWrapper>
   );
+};
+
+Radio.defaultProps = {
+  className: '',
 };
 
 export default Radio;

--- a/src/components/TabSwitcher/index.js
+++ b/src/components/TabSwitcher/index.js
@@ -11,6 +11,8 @@ type Props = {
   tabs: Array<TabInfo>,
   selectedTabIndex: number,
   onTabClick: (index: number) => void,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
 const renderTabs = (
@@ -32,9 +34,15 @@ const renderTabs = (
     </Tab>
   ));
 
-const TabSwitcher = ({ tabs, selectedTabIndex, onTabClick }: Props) =>
+const TabSwitcher = ({ tabs, selectedTabIndex, onTabClick, className }: Props) =>
   tabs ? (
-    <TabSwitchContainer>{renderTabs(tabs, selectedTabIndex, onTabClick)}</TabSwitchContainer>
+    <TabSwitchContainer className={className}>
+      {renderTabs(tabs, selectedTabIndex, onTabClick)}
+    </TabSwitchContainer>
   ) : null;
+
+TabSwitcher.defaultProps = {
+  className: '',
+};
 
 export default TabSwitcher;

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -6,14 +6,20 @@ type Props = {
   placement: string,
   dataTip: string,
   children: Node,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
-const Tooltip = ({ placement, dataTip, children }: Props) => (
-  <TooltipWrapper>
+const Tooltip = ({ placement, dataTip, children, className }: Props) => (
+  <TooltipWrapper className={className}>
     <span tooltip={dataTip} flow={placement}>
       {children}
     </span>
   </TooltipWrapper>
 );
+
+Tooltip.defaultProps = {
+  className: '',
+};
 
 export default Tooltip;

--- a/src/elements/Switcher/index.js
+++ b/src/elements/Switcher/index.js
@@ -11,16 +11,18 @@ type Props = {
   id: string,
   label: string,
   onChange: (checked: boolean) => any,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
-const Switcher = ({ id, checked, label, disabled, onChange }: Props) => {
+const Switcher = ({ id, checked, label, disabled, onChange, className }: Props) => {
   const onToggleChange = (e: SyntheticInputEvent<*>) => {
     if (e.target) {
       onChange(e.target.checked);
     }
   };
   return (
-    <SwitchWrapper>
+    <SwitchWrapper className={className}>
       <Toggle
         id={id}
         disabled={disabled}
@@ -31,6 +33,10 @@ const Switcher = ({ id, checked, label, disabled, onChange }: Props) => {
       <Label htmlFor={id}>{label}</Label>
     </SwitchWrapper>
   );
+};
+
+Switcher.defaultProps = {
+  className: '',
 };
 
 /** @component */

--- a/src/elements/Typography/index.js
+++ b/src/elements/Typography/index.js
@@ -31,14 +31,28 @@ export type TypographyProps = {
   variant: TypographyVariant,
   description: ?boolean,
   children: Node,
+  /** A className can be passed down for further styling or extending with CSS-in-JS */
+  className?: string,
 };
 
-const Typography = ({ variant, children, description }: TypographyProps) => {
+const Typography = ({ variant, children, description, className }: TypographyProps) => {
   if (variant === 'p') {
-    return <Paragraph description={description}>{children}</Paragraph>;
+    return (
+      <Paragraph className={className} description={description}>
+        {children}
+      </Paragraph>
+    );
   }
   const Component = Heading.withComponent(variant);
-  return <Component variant={variant}>{children}</Component>;
+  return (
+    <Component className={className} variant={variant}>
+      {children}
+    </Component>
+  );
+};
+
+Typography.defaultProps = {
+  className: '',
 };
 
 export default Typography;


### PR DESCRIPTION
## OVERVIEW

Adds a `className` props to components that we have defined and are not styled-components, so that they can be styled and extended with CSS-in-JS libraries.

## WHERE SHOULD THE REVIEWER START?

`src/components`,
`src/elements`
