### PR TITLE
Use white default background color for dropdown

### DIFF
--- a/src/elements/Dropdown/index.js
+++ b/src/elements/Dropdown/index.js
@@ -9,6 +9,7 @@ import colors from 'config/colors';
 
 const DropdownContainer = styled.select`
   border: 1px solid ${colors.gray};
+  background-color: ${colors.white};
   border-radius: 2px;
   color: ${uiColors('text.light')};
   cursor: pointer;


### PR DESCRIPTION
## OVERVIEW

_Added white background color as default for the dropdown._

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/elements/Dropdown.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_None._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

![dropdown](https://user-images.githubusercontent.com/16154503/51385056-62ad3c80-1b1e-11e9-8e6a-c142066bf2be.png)

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master

## GIF

_Share a [fun GIF](https://media.giphy.com/media/WRZWgSXZaE0u1ryFT6/giphy.gif) to say thanks to your reviewer:_
