### PR TITLE
Make Label disabled prop optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.1.4] - 06-02-2019
+
+### Fixes
+
+- Body global style primary color to palette text main color
+
+### Changes
+
+- Label `disabled` prop to be optional
+
 # [0.1.3] - 18-01-2019
 
 ### Added

--- a/src/config/globalStyles.js
+++ b/src/config/globalStyles.js
@@ -7,7 +7,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   body {
-    color: ${props => props.theme.palette.primary.main};
+    color: ${props => props.theme.palette.text.main};
     font-family: ${props => props.theme.font.primaryFallback};
     font-size: ${props => props.theme.font.sizes.medium}px;
     font-weight: 400;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -322,7 +322,7 @@ export declare const Dropdown: FunctionComponent<DropdownProps>;
 export declare const Icon: StyledComponent<any, Theme>;
 
 export interface LabelProps {
-  disabled: boolean;
+  disabled?: boolean;
 }
 
 export declare const Label: StyledComponent<'label', Theme, LabelProps>;


### PR DESCRIPTION
## OVERVIEW

Set `disabled` prop on the Label component is optional and change globalStyles color to palette text main color.

## WHERE SHOULD THE REVIEWER START?

- `/src/utils/index.d.ts`
- `/src/config/globalStyles`

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
