### PR TITLE
No issue/fix/replace FontFaceObserver with WebFontLoader

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "flow-bin": "^0.91.0",
     "flow-typed": "^2.5.1",
     "flow-watch": "^1.1.4",
-    "fontfaceobserver": "^2.1.0",
     "husky": "^1.3.1",
     "jest": "^23.6.0",
     "jest-styled-components": "^6.3.1",
@@ -161,6 +160,7 @@
     "stylelint-config-standard": "^18.2.0",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.5.2",
+    "webfontloader": "^1.6.28",
     "webpack": "^4.28.4",
     "webpack-cli": "^3.2.1"
   },

--- a/src/config/configureFonts.js
+++ b/src/config/configureFonts.js
@@ -1,18 +1,13 @@
-import FontFaceObserver from 'fontfaceobserver';
+import WebFont from 'webfontloader';
 
 function configureFonts(theme) {
-  const fontObservers = [new FontFaceObserver(theme.font.primary)];
+  const fonts = [theme.font.primary];
 
-  function fontLoadSuccess() {
-    document.body.classList.add('fonts-loaded');
-  }
-
-  function fontLoadFailure(e) {
-    console.error('ERROR', e);
-    document.body.classList.remove('fonts-loaded');
-  }
-
-  Promise.all(fontObservers.map(o => o.load())).then(fontLoadSuccess, fontLoadFailure);
+  WebFont.load({
+    google: {
+      families: fonts,
+    },
+  });
 
   return true;
 }

--- a/src/config/globalStyles.js
+++ b/src/config/globalStyles.js
@@ -4,31 +4,33 @@ import { createGlobalStyle } from 'styled-components';
 const GlobalStyle = createGlobalStyle`
   html {
     height: 100%;
-  }
 
-  body {
-    color: ${props => props.theme.palette.text.main};
-    font-family: ${props => props.theme.font.primaryFallback};
-    font-size: ${props => props.theme.font.sizes.medium}px;
-    font-weight: 400;
-    height: 100%;
-    margin: 0;
-
-    button,
-    input,
-    select,
-    textarea {
+    body {
+      color: ${props => props.theme.palette.text.main};
       font-family: ${props => props.theme.font.primaryFallback};
+      font-size: ${props => props.theme.font.sizes.medium}px;
+      font-weight: 400;
+      height: 100%;
+      margin: 0;
+
+      button,
+      input,
+      select,
+      textarea {
+        font-family: ${props => props.theme.font.primaryFallback};
+      }
     }
 
-    &.fonts-loaded {
+    &.wf-active {
       font-family: ${props => props.theme.font.primary};
+      font-weight: 300;
 
       button,
       input,
       select,
       textarea {
         font-family: ${props => props.theme.font.primary};
+        font-weight: 300;
       }
     }
   }

--- a/src/config/globalStyles.js
+++ b/src/config/globalStyles.js
@@ -9,7 +9,7 @@ const GlobalStyle = createGlobalStyle`
       color: ${props => props.theme.palette.text.main};
       font-family: ${props => props.theme.font.primaryFallback};
       font-size: ${props => props.theme.font.sizes.medium}px;
-      font-weight: 400;
+      font-weight: 300;
       height: 100%;
       margin: 0;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4668,11 +4668,6 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "=3.1.0"
 
-fontfaceobserver@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz#e2705d293e2c585a6531c2a722905657317a2991"
-  integrity sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==
-
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -11932,6 +11927,11 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webfontloader@^1.6.28:
+  version "1.6.28"
+  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
+  integrity sha1-23hhKSU8tujq5UwvsF+HCvZnW64=
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## OVERVIEW

FontFaceObserver would not load fonts correctly, so I replaced it with WebFontLoader, along with some global styles adjustments.

## WHERE SHOULD THE REVIEWER START?

`src/config/configureFonts.js`
`src/config/globalStyles.js`

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

WebFontLoader

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_
