### PR TITLE
No issue/fix/Add custom ThemeProvider prop to ThemeWrapper

### DIFF
--- a/src/config/configureFonts.js
+++ b/src/config/configureFonts.js
@@ -1,7 +1,7 @@
 import WebFont from 'webfontloader';
 
 function configureFonts(theme) {
-  const fonts = [theme.font.primary];
+  const fonts = [`${theme.font.primary}:100,300,400,500,700`];
 
   WebFont.load({
     google: {

--- a/src/config/theme.js
+++ b/src/config/theme.js
@@ -30,7 +30,7 @@ module.exports = {
       thin: 100,
       light: 300,
       normal: 400,
-      semiBold: 600,
+      semiBold: 500,
       bold: 700,
     },
     sizes: {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,10 @@ import {
   SyntheticEvent,
   ButtonHTMLAttributes,
 } from 'react';
-import { StyledComponent } from 'styled-components';
+import {
+  StyledComponent,
+  ThemeProviderComponent,
+} from 'styled-components';
 import moment from 'moment';
 
 interface ColumnProps {
@@ -510,8 +513,14 @@ export interface Theme {
 export interface ThemeWrapperProps {
   children: ReactNode;
   theme?: Theme;
+  withProvider: ThemeProviderComponent<Theme>;
 }
-
+/**
+ * A component which adds the theme to the library components.
+ * Theme prop is optional - it will use the default theme if no theme is provided.
+ * The ThemeProvider component from your styled-components version must be provided as a prop to withProvider,
+ * to inject the theme into your styled-components as well.
+ */
 export declare const ThemeWrapper: FunctionComponent<ThemeWrapperProps>;
 
 interface IColors {

--- a/src/theme/ThemeWrapper.js
+++ b/src/theme/ThemeWrapper.js
@@ -1,24 +1,30 @@
 // @flow
 import React, { Fragment } from 'react';
-import type { Node } from 'react';
-import { ThemeProvider } from 'styled-components';
+import type { Node, ComponentType } from 'react';
+import { ThemeProvider as DefaultThemeProvider } from 'styled-components';
 import GlobalStyles from 'config/globalStyles';
 import configureFonts from 'config/configureFonts';
 import fallbackTheme from 'config/theme';
 import type { Theme } from 'types/Theme';
 
-type Props = { children: Node, theme: ?Theme };
+type Props = {
+  children: Node,
+  theme: ?Theme,
+  withProvider: ComponentType,
+};
 
-const ThemeWrapper = ({ children, theme }: Props) => {
+const ThemeWrapper = ({ children, theme, withProvider: Provider }: Props) => {
   const appTheme = theme || fallbackTheme;
   configureFonts(appTheme);
   return (
-    <ThemeProvider theme={appTheme}>
-      <Fragment>
-        <GlobalStyles suppressMultiMountWarning />
-        {children}
-      </Fragment>
-    </ThemeProvider>
+    <Provider theme={appTheme}>
+      <DefaultThemeProvider theme={appTheme}>
+        <Fragment>
+          <GlobalStyles suppressMultiMountWarning />
+          {children}
+        </Fragment>
+      </DefaultThemeProvider>
+    </Provider>
   );
 };
 


### PR DESCRIPTION
## OVERVIEW

Adds the `withProvider` prop to `ThemeWrapper` to allow the user to inject the `ThemeProvider` from his styled-components version and inject the theme into his created components.

Also fixes some small style issues.

## WHERE SHOULD THE REVIEWER START?

`/src/theme/ThemeWrapper.js`

## HOW CAN THIS BE MANUALLY TESTED?

Create a new application. Add the library as dependency. Wrap it in ThemeWrapper and provide the ThemeProvider from 'styled-components'. Create a new component and use the provided theme in it. See if it works and doesn't crash.
