### PR TITLE
No issue/change/Enable generic types for Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 - Add `showLoader` prop to Table.
 - Add generic for the data type to Table.
+- Enable generic types for Button.
 
 ### Fixes
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -259,9 +259,11 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, Bu
   size?: ButtonSize;
   style?: CSSProperties;
   className?: string;
+  as?: ReactElement;
 }
 
-export declare const Button: FunctionComponent<ButtonProps>;
+export declare class Button<T = {}> extends React.Component<T & ButtonProps> {
+}
 
 export interface CardProps {
   title?: string;


### PR DESCRIPTION
## OVERVIEW

change: Modify Button to accept `as` and generic.

* Enables styled-components polymorphic `as` usage.

* Generic is meant for passing props for the new component.

## WHERE SHOULD THE REVIEWER START?

`/src/index.d.ts`

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
