### PR TITLE
114/hotfix/dropdown props matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 
 - Fix an issue with wrong text color on the selected pagination page
+- Add missing Dropdown props
 
 ### Added
 

--- a/src/elements/PillLabel/tests/__snapshots__/index.js.snap
+++ b/src/elements/PillLabel/tests/__snapshots__/index.js.snap
@@ -2,24 +2,13 @@
 
 exports[`PillLabel renders correctly 1`] = `
 .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: inline-block;
   background: #fff;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   color: #44494e;
   font-weight: 300;
   border: 1px solid #d7dde5;
   border-radius: 1rem;
   font-size: 1rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
   outline: none;
   vertical-align: middle;
   -webkit-letter-spacing: 0.015em;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -321,7 +321,9 @@ export interface DropdownProps extends HTMLSelectElement {
   value: string;
   onChange: (value: string) => any;
   color?: string;
-  items: Array<Option>;
+  options: Array<Option>;
+  className?: string;
+  style?: CSSProperties;
 }
 
 export declare const Dropdown: FunctionComponent<DropdownProps>;
@@ -397,7 +399,6 @@ interface PillLabelProps {
 }
 
 export declare const PillLabel: StyledComponent<'span', Theme, PillLabelProps>;
-
 
 type ProgressType = 'circle' | 'line';
 


### PR DESCRIPTION
## OVERVIEW

_Dropdown props inconsistencies._

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/index.d.ts`_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master

## GIF

_Share a [fun GIF](https://giphy.com) to say thanks to your reviewer:_

![](https://media.giphy.com/media/agreJq9Bgwrks/giphy.gif)
