### PR TITLE
fix: Add checks for existence of optional props.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-# [0.4.1] - 21-02-2019
+# [0.5.0] - 21-02-2019
+
+### Changes
+- Enhance and modify Table API with generics and better type checking
 
 ### Fixes
 - Table and DropDown prop definition types
+- Fix Table crashing from accessing properties of optional props
 
 # [0.4.0] - 20-02-2019
 

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -149,13 +149,10 @@ class Table extends React.Component<Props, State> {
 
   generateRows = (data: Array<Data>) => {
     const { options } = this.props;
-    const {
-      rowSelection: { active },
-      rowActions,
-    } = options;
+    const { rowSelection, rowActions } = options;
     let newData = [...data];
 
-    if (active) {
+    if (rowSelection && rowSelection.active) {
       const { selected } = this.state;
 
       newData = data.map(dataCell => ({
@@ -170,7 +167,7 @@ class Table extends React.Component<Props, State> {
       }));
     }
 
-    if (rowActions) {
+    if (rowActions && rowActions.length) {
       newData = newData.map(dataCell => ({
         ...dataCell,
         actions: rowActions.map((action, index) => (
@@ -185,14 +182,11 @@ class Table extends React.Component<Props, State> {
   generateColumns = (columns: Array<Column>) => {
     const { selectedAll } = this.state;
     const { options } = this.props;
-    const {
-      rowSelection: { active },
-      rowActions,
-    } = options;
+    const { rowSelection, rowActions } = options;
 
     let newColumns = [...columns];
 
-    if (active) {
+    if (rowSelection && rowSelection.active) {
       const rowCheckbox = {
         title: (
           <TableCheckbox id="toggleAll" checked={selectedAll} onChange={this.toggleSelectAll} />
@@ -203,7 +197,7 @@ class Table extends React.Component<Props, State> {
       newColumns = [rowCheckbox, ...columns];
     }
 
-    if (rowActions) {
+    if (rowActions && rowActions.length) {
       const actionsColumn = { title: 'Actions', key: 'actions' };
       newColumns = [...newColumns, actionsColumn];
     }


### PR DESCRIPTION
## OVERVIEW

Some properties of the optional props were accessed without checking if the props exist, which caused the app to crash. This PR adds these checks and only accesses the properties if the prop exists.

## WHERE SHOULD THE REVIEWER START?

`/src/components/Table/index.js`

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
