### PR TITLE
No issue/fix/Fix Input onChange not passing entire event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 - Fix Input handling of onChange event
 
+### Added
+- Add new `pale (#f0f3f6)` color to Colors object
+
 # [0.7.0] - 28-02-2019
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.7.1] - 01-03-2019
+
+### Fixes
+- Fix Input handling of onChange event
+
 # [0.7.0] - 28-02-2019
 
 ### Changes

--- a/src/config/colors.js
+++ b/src/config/colors.js
@@ -25,4 +25,5 @@ module.exports = {
   paleYellow: '#fffcee',
   green: '#5dc6a3',
   paleGreen: '#e4f9f2',
+  pale: '#f0f3f6',
 };

--- a/src/elements/Input/Readme.md
+++ b/src/elements/Input/Readme.md
@@ -8,7 +8,7 @@ function Page(props) {
     <Input
       type="text"
       placeholder="text"
-      onChange={() => console.log('onChange')}
+      onChange={console.log}
     />
   );
 }
@@ -20,13 +20,13 @@ function Page(props) {
 <Input
   type="text"
   placeholder="text"
-  onChange={() => console.log('onChange')}
+  onChange={console.log}
   style={{ margin: '6px 0' }}
 />
 <Input
   type="search"
   placeholder="Search"
-  onChange={() => console.log('onChange')}
+  onChange={console.log}
   style={{ margin: '6px 0' }}
 />
 ```

--- a/src/elements/Input/index.js
+++ b/src/elements/Input/index.js
@@ -69,7 +69,12 @@ type Props = {
 };
 
 const Input = ({ type, placeholder, onChange, ...rest }: Props) => {
-  const onInputChange = (e: SyntheticEvent<HTMLInputElement>): any => onChange(e.target.value);
+  const onInputChange = (e: SyntheticEvent<HTMLInputElement>): any => {
+    e.persist();
+    if (onChange) {
+      onChange(e);
+    }
+  };
 
   return type === 'search' ? (
     <SearchWrapper>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -612,6 +612,7 @@ interface IColors {
   paleYellow: '#fffcee';
   green: '#5dc6a3';
   paleGreen: '#e4f9f2';
+  pale: '#f0f3f6';
 }
 
 export declare const Colors: IColors;


### PR DESCRIPTION
## OVERVIEW

The Input field wrapped the call to onChange prop and passed only the value. Now it passes the entire event.

## WHERE SHOULD THE REVIEWER START?

`/src/elements/Input/index.js`

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
