### PR TITLE
139/hotfix/update pagination props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.9.0] - 07-03-2019
+
+### Changes
+
+- Remove unused Pagination prop currentPage
+- Add missing optional Pagination prop forcePage
+
 # [0.8.2] - 06-03-2019
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-# [0.9.0] - 07-03-2019
+# [0.8.3] - 07-03-2019
 
-### Changes
+### Fixes
 
-- Remove unused Pagination prop currentPage
-- Add missing optional Pagination prop forcePage
+- Put unused Pagination prop currentPage into use
 
 # [0.8.2] - 06-03-2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
-- Put unused Pagination prop currentPage into use
+- Passed down Pagination currentPage prop to forcePage of ReactPaginate
 
 # [0.8.2] - 06-03-2019
 

--- a/src/elements/Pagination/index.js
+++ b/src/elements/Pagination/index.js
@@ -7,7 +7,6 @@ import PaginationWrapper from './PaginationWrapper';
 
 type Props = {
   pageCount: number,
-  currentPage: number,
   pageRangeDisplayed: number,
   marginPagesDisplayed: number,
   previousLabel: string,
@@ -16,6 +15,7 @@ type Props = {
   onPageChange: (data: { selected: number }) => any,
   breakClassName?: string,
   initialPage?: number,
+  forcePage?: number,
   disableInitialCallback?: boolean,
   containerClassName?: string,
   pageClassName?: string,
@@ -50,6 +50,7 @@ const Pagination = ({ style, className, ...rest }: Props) => (
 Pagination.defaultProps = {
   breakClassName: 'break',
   initialPage: 0,
+  forcePage: 0,
   disableInitialCallback: false,
   containerClassName: '',
   pageClassName: '',

--- a/src/elements/Pagination/index.js
+++ b/src/elements/Pagination/index.js
@@ -7,6 +7,7 @@ import PaginationWrapper from './PaginationWrapper';
 
 type Props = {
   pageCount: number,
+  currentPage: number,
   pageRangeDisplayed: number,
   marginPagesDisplayed: number,
   previousLabel: string,
@@ -15,7 +16,6 @@ type Props = {
   onPageChange: (data: { selected: number }) => any,
   breakClassName?: string,
   initialPage?: number,
-  forcePage?: number,
   disableInitialCallback?: boolean,
   containerClassName?: string,
   pageClassName?: string,
@@ -39,10 +39,10 @@ const PaginationPositioning = styled.div`
   text-align: center;
 `;
 
-const Pagination = ({ style, className, ...rest }: Props) => (
+const Pagination = ({ style, className, currentPage, ...rest }: Props) => (
   <PaginationPositioning style={style} className={className}>
     <PaginationWrapper>
-      <ReactPaginate {...rest} />
+      <ReactPaginate forcePage={currentPage} {...rest} />
     </PaginationWrapper>
   </PaginationPositioning>
 );
@@ -50,7 +50,6 @@ const Pagination = ({ style, className, ...rest }: Props) => (
 Pagination.defaultProps = {
   breakClassName: 'break',
   initialPage: 0,
-  forcePage: 0,
   disableInitialCallback: false,
   containerClassName: '',
   pageClassName: '',


### PR DESCRIPTION
## OVERVIEW

Previously unused Pagination prop `currentPage` put into use for `react-paginate`:
`<ReactPaginate forcePage={currentPage} {...rest} />`

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/elements/Pagination/index.js`_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
