### PR TITLE
No issue/change/Modify Radio onChange API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.9.0] - 11-03-2019
+
+### Changes
+
+- Change onChange of Radio to accept ChangeEvent instead of boolean
+
+
 # [0.8.3] - 07-03-2019
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 - Change onChange of Radio to accept ChangeEvent instead of boolean
 
+### Fixes
+
+- Fix font-family from user agent stylesheet overriding HTML elements
 
 # [0.8.3] - 07-03-2019
 

--- a/src/components/Radio/index.js
+++ b/src/components/Radio/index.js
@@ -8,25 +8,24 @@ type Props = {
   id: string,
   name: ?string,
   checked: boolean,
-  onChange: (checked: boolean) => any,
+  onChange: (e: SyntheticEvent<HTMLInputElement>) => any,
+  onBlur?: (e: any) => any,
   /** A className can be passed down for further styling or extending with CSS-in-JS */
   className?: string,
   style?: Object,
 };
 
-const Radio = ({ label, id, checked, onChange, className, style, ...rest }: Props) => {
-  const onRadioChange = (e: SyntheticEvent<HTMLInputElement>): any => onChange(e.target.checked);
-  return (
-    <RadioWrapper className={className} style={style}>
-      <input type="radio" id={id} checked={checked} onChange={onRadioChange} {...rest} />
-      <Label htmlFor={id}>{label}</Label>
-    </RadioWrapper>
-  );
-};
+const Radio = ({ label, id, checked, onChange, className, style, ...rest }: Props) => (
+  <RadioWrapper className={className} style={style}>
+    <input type="radio" id={id} checked={checked} onChange={onChange} {...rest} />
+    <Label htmlFor={id}>{label}</Label>
+  </RadioWrapper>
+);
 
 Radio.defaultProps = {
   className: '',
   style: {},
+  onBlur: () => {},
 };
 
 export default Radio;

--- a/src/components/Radio/tests/__snapshots__/index.js.snap
+++ b/src/components/Radio/tests/__snapshots__/index.js.snap
@@ -135,7 +135,7 @@ exports[`Radio renders correctly 1`] = `
   style={Object {}}
 >
   <input
-    onChange={[Function]}
+    onBlur={[Function]}
     type="radio"
   />
   <label

--- a/src/config/globalStyles.js
+++ b/src/config/globalStyles.js
@@ -7,15 +7,26 @@ const GlobalStyle = createGlobalStyle`
 
     body {
       color: ${props => props.theme.palette.text.main};
-      font-family: ${props => props.theme.font.primaryFallback};
       font-size: ${props => props.theme.font.sizes.medium}px;
-      font-weight: 300;
       height: 100%;
       margin: 0;
     }
 
+    body,
+    input,
+    textarea,
+    select,
+    button {
+      font-family: ${props => props.theme.font.primaryFallback};
+      font-weight: 300;
+    }
+
     &.wf-active {
-      body {
+      body,
+      input,
+      textarea,
+      select,
+      button {
         font-family: ${props => props.theme.font.primary};
         font-weight: 300;
       }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,7 @@ import {
   ButtonHTMLAttributes,
   HTMLAttributes,
   AllHTMLAttributes,
+  ChangeEvent,
 } from 'react';
 import {
   StyledComponent,
@@ -154,7 +155,8 @@ export interface RadioProps {
   id: string;
   name?: string;
   checked: boolean;
-  onChange: (checked: boolean) => any;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => any;
+  onBlur?: (e: any) => any;
   className?: string;
   style?: CSSProperties;
 }


### PR DESCRIPTION
## OVERVIEW

Updates the Radio input button to accept the entire onChange event handler instead of wrapping the onChange and passing a boolean value.

* Adds optional onBlur prop to Radio.
* Fixes an issue where the specificity of browser styles overrides HTML elements.

## WHERE SHOULD THE REVIEWER START?

`/src/components/Radio/index.js`

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
