### PR TITLE
145/improvement/switch disabled prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.9.3] - 12-03-2019
+
+### Changes
+
+- Make disabled prop optional on Switch
+
 # [0.9.2] - 11-03-2019
 
 ### Fixes

--- a/src/elements/Switch/index.js
+++ b/src/elements/Switch/index.js
@@ -6,7 +6,7 @@ import Label from '../Label';
 
 type Props = {
   checked: boolean,
-  disabled: boolean,
+  disabled?: boolean,
   id: string,
   label: string,
   onChange: (checked: boolean) => any,
@@ -40,6 +40,7 @@ const Switch = ({ id, checked, label, disabled, onChange, className, style }: Pr
 Switch.defaultProps = {
   className: '',
   style: {},
+  disabled: false,
 };
 
 /** @component */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -492,7 +492,7 @@ export declare class SingleDayPicker extends Component<SingleDayPickerProps, Sin
 
 export interface SwitchProps {
   checked: boolean;
-  disabled: boolean;
+  disabled?: boolean;
   id: string;
   label: string;
   onChange: (checked: boolean) => any;


### PR DESCRIPTION
## OVERVIEW

Switch `disabled` prop is now optional

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/elements/Switch/index.js`_
