### PR TITLE
Add fullheight prop to Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.10.0] - 14-03-2019
+
+### Changes
+
+- Add fullHeight prop to Button
+
 # [0.9.5] - 13-03-2019
 
 ### Changes

--- a/src/elements/Button/ButtonWrapper.js
+++ b/src/elements/Button/ButtonWrapper.js
@@ -146,6 +146,12 @@ const ButtonWrapper = styled.button`
       width: 100%;
     `
   )};
+  ${ifProp(
+    'fullHeight',
+    css`
+      height: 100%;
+    `
+  )};
 `;
 
 ButtonWrapper.defaultProps = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -301,6 +301,7 @@ export interface ButtonProps<T> extends ButtonHTMLAttributes<HTMLButtonElement>,
   className?: string;
   as?: ComponentType<T>;
   fullWidth?: boolean;
+  fullHeight?: boolean;
 }
 
 export declare class Button<T = {}> extends Component<T & ButtonProps<T>> { }


### PR DESCRIPTION
## OVERVIEW

_Add fullHeight prop to Button._

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/elements/Button.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_None._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
