### PR TITLE
Add margin left to the Label in Switch component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.10.2] - 19-03-2019
+
+### Fixes
+
+- Add margin left to the Label in Switch component
+
 # [0.10.1] - 18-03-2019
 
 ### Changes

--- a/src/elements/Switch/index.js
+++ b/src/elements/Switch/index.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import styled from 'styled-components';
 import Toggle from 'react-toggle';
 import SwitchWrapper from './SwitchWrapper';
 import Label from '../Label';
@@ -14,6 +15,10 @@ type Props = {
   className?: string,
   style?: Object,
 };
+
+const MarginLeftLabel = styled(Label)`
+  margin-left: 0.5rem;
+`;
 
 const Switch = ({ id, checked, label, disabled, onChange, className, style }: Props) => {
   const onToggleChange = (e: SyntheticInputEvent<*>) => {
@@ -30,9 +35,9 @@ const Switch = ({ id, checked, label, disabled, onChange, className, style }: Pr
         onChange={onToggleChange}
         icons={false}
       />
-      <Label disabled={disabled} htmlFor={id}>
+      <MarginLeftLabel disabled={disabled} htmlFor={id}>
         {label}
-      </Label>
+      </MarginLeftLabel>
     </SwitchWrapper>
   );
 };

--- a/src/elements/Switch/tests/__snapshots__/index.js.snap
+++ b/src/elements/Switch/tests/__snapshots__/index.js.snap
@@ -153,6 +153,7 @@ exports[`Switch renders correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  margin-left: 0.5rem;
 }
 
 .c1:not(:disabled):hover {


### PR DESCRIPTION
## OVERVIEW

_Add margin left to the Label in Switch component._

## WHERE SHOULD THE REVIEWER START?

`/src/elements/Switch.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_None._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

![switch](https://user-images.githubusercontent.com/16154503/54592882-89f48d00-4a2d-11e9-891d-4df3b9673214.png)

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
