### PR TITLE
Use same padding value for Input and Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.11.1] - 22-03-2019
+
+### Fixes
+
+- Use same padding sizes for Input and Dropdown
+- Use rem unit for spacing through out the app
+
 # [0.11.0] - 21-03-2019
 
 ### Added

--- a/src/components/Modal/ModalContent.js
+++ b/src/components/Modal/ModalContent.js
@@ -7,7 +7,7 @@ type Props = {
 };
 
 const ContentContainer = styled.div`
-  padding: 10px 20px 20px 20px;
+  padding: 0.625rem 1.25rem;
   box-sizing: border-box;
 `;
 

--- a/src/components/Modal/ModalHeader.js
+++ b/src/components/Modal/ModalHeader.js
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const HeaderWrapper = styled.div`
-  padding: 20px 20px 10px 20px;
+  padding: 1.25rem;
   box-sizing: border-box;
   position: relative;
   border-bottom: 1px solid ${colors.gray};
@@ -23,10 +23,10 @@ const Title = styled(Typography)`
 
 const IconClose = styled.span`
   position: absolute;
-  height: 18px;
-  width: 18px;
-  top: 10px;
-  right: 10px;
+  height: 1.125rem;
+  width: 1.125rem;
+  top: 0.625rem;
+  right: 0.625rem;
   cursor: pointer;
 
   &::before {

--- a/src/components/Modal/tests/__snapshots__/index.js.snap
+++ b/src/components/Modal/tests/__snapshots__/index.js.snap
@@ -9,7 +9,7 @@ exports[`Modal renders correctly 1`] = `
 }
 
 .c2 {
-  padding: 20px 20px 10px 20px;
+  padding: 1.25rem;
   box-sizing: border-box;
   position: relative;
   border-bottom: 1px solid #d7dde5;
@@ -21,10 +21,10 @@ exports[`Modal renders correctly 1`] = `
 
 .c5 {
   position: absolute;
-  height: 18px;
-  width: 18px;
-  top: 10px;
-  right: 10px;
+  height: 1.125rem;
+  width: 1.125rem;
+  top: 0.625rem;
+  right: 0.625rem;
   cursor: pointer;
 }
 
@@ -34,7 +34,7 @@ exports[`Modal renders correctly 1`] = `
 }
 
 .c6 {
-  padding: 10px 20px 20px 20px;
+  padding: 0.625rem 1.25rem;
   box-sizing: border-box;
 }
 

--- a/src/components/NavBar/Arrow.js
+++ b/src/components/NavBar/Arrow.js
@@ -7,7 +7,7 @@ import { transparentize } from 'polished';
 
 export const ArrowContainer = styled.div`
   width: 18px;
-  margin: 0 17px 16px 15px;
+  margin: 0 1rem 1rem 1rem;
   align-self: flex-end;
   text-align: center;
 
@@ -20,7 +20,7 @@ export const NavbarArrow = styled.i`
   border: solid ${transparentize(0.6, colors.white)};
   border-width: 1px 0 0 1px;
   display: inline-block;
-  padding: 3px;
+  padding: 0.225rem;
   transform: ${ifProp('open', 'rotate(-45deg)', 'rotate(135deg)')};
   transition: all 0.5s ease;
 `;

--- a/src/components/NavBar/MenuItem.js
+++ b/src/components/NavBar/MenuItem.js
@@ -31,7 +31,7 @@ const MenuItemContainer = styled.div`
 `;
 
 const MenuItemIcon = styled.i`
-  margin: 0 17px 0 15px;
+  margin: 0 1rem;
   width: 20px;
   min-width: 20px;
 `;

--- a/src/components/NavBar/styled.js
+++ b/src/components/NavBar/styled.js
@@ -17,13 +17,13 @@ export const NavbarContainer = styled.div`
 export const NavbarLogo = styled.img`
   align-self: center;
   height: 34px;
-  margin: 8px 0;
+  margin: 0.5rem 0;
 `;
 
 export const MenuContainer = styled.nav`
   width: 100%;
   text-align: left;
-  margin: 50px 0 0;
+  margin: 3.125rem 0 0;
 `;
 
 export const LogoMenuContainer = styled.span`

--- a/src/components/NavBar/tests/__snapshots__/Arrow.test.js.snap
+++ b/src/components/NavBar/tests/__snapshots__/Arrow.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Arrow renders correctly 1`] = `
 .c0 {
   width: 18px;
-  margin: 0 17px 16px 15px;
+  margin: 0 1rem 1rem 1rem;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
@@ -18,7 +18,7 @@ exports[`Arrow renders correctly 1`] = `
   border: solid rgba(255,255,255,0.4);
   border-width: 1px 0 0 1px;
   display: inline-block;
-  padding: 3px;
+  padding: 0.225rem;
   -webkit-transform: rotate(135deg);
   -ms-transform: rotate(135deg);
   transform: rotate(135deg);

--- a/src/components/NavBar/tests/__snapshots__/MenuItem.test.js.snap
+++ b/src/components/NavBar/tests/__snapshots__/MenuItem.test.js.snap
@@ -25,7 +25,7 @@ exports[`MenuItem renders correctly 1`] = `
 }
 
 .c1 {
-  margin: 0 17px 0 15px;
+  margin: 0 1rem;
   width: 20px;
   min-width: 20px;
 }

--- a/src/components/NavBar/tests/__snapshots__/MenuWithLogo.test.js.snap
+++ b/src/components/NavBar/tests/__snapshots__/MenuWithLogo.test.js.snap
@@ -6,13 +6,13 @@ exports[`MenuWithLogo renders correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   height: 34px;
-  margin: 8px 0;
+  margin: 0.5rem 0;
 }
 
 .c2 {
   width: 100%;
   text-align: left;
-  margin: 50px 0 0;
+  margin: 3.125rem 0 0;
 }
 
 .c0 {

--- a/src/components/NavBar/tests/__snapshots__/index.js.snap
+++ b/src/components/NavBar/tests/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`Navbar renders correctly 1`] = `
 .c4 {
   width: 18px;
-  margin: 0 17px 16px 15px;
+  margin: 0 1rem 1rem 1rem;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
@@ -18,7 +18,7 @@ exports[`Navbar renders correctly 1`] = `
   border: solid rgba(255,255,255,0.4);
   border-width: 1px 0 0 1px;
   display: inline-block;
-  padding: 3px;
+  padding: 0.225rem;
   -webkit-transform: rotate(135deg);
   -ms-transform: rotate(135deg);
   transform: rotate(135deg);
@@ -52,13 +52,13 @@ exports[`Navbar renders correctly 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   height: 34px;
-  margin: 8px 0;
+  margin: 0.5rem 0;
 }
 
 .c3 {
   width: 100%;
   text-align: left;
-  margin: 50px 0 0;
+  margin: 3.125rem 0 0;
 }
 
 .c1 {

--- a/src/components/Note/NoteWrapper.js
+++ b/src/components/Note/NoteWrapper.js
@@ -6,7 +6,7 @@ import { fontWeights, uiColors } from 'utils';
 const NoteWrapper = styled.p`
   box-sizing: border-box;
   border: 1px solid ${colors.gray};
-  padding: 18px 2%;
+  padding: 1.125rem 2%;
   border-radius: 3px;
   background: ${colors.white};
   color: ${uiColors('text.main')};
@@ -15,11 +15,11 @@ const NoteWrapper = styled.p`
   line-height: 1.8;
 
   strong {
-    padding-right: 5px;
+    padding-right: 0.3125rem;
   }
 
   i {
-    margin-right: 12px;
+    margin-right: 0.75rem;
     position: relative;
     top: 2px;
   }

--- a/src/components/Note/tests/__snapshots__/index.js.snap
+++ b/src/components/Note/tests/__snapshots__/index.js.snap
@@ -4,7 +4,7 @@ exports[`Note renders correctly 1`] = `
 .c0 {
   box-sizing: border-box;
   border: 1px solid #d7dde5;
-  padding: 18px 2%;
+  padding: 1.125rem 2%;
   border-radius: 3px;
   background: #fff;
   color: #44494e;
@@ -17,11 +17,11 @@ exports[`Note renders correctly 1`] = `
 }
 
 .c0 strong {
-  padding-right: 5px;
+  padding-right: 0.3125rem;
 }
 
 .c0 i {
-  margin-right: 12px;
+  margin-right: 0.75rem;
   position: relative;
   top: 2px;
 }

--- a/src/components/Radio/RadioWrapper.js
+++ b/src/components/Radio/RadioWrapper.js
@@ -13,7 +13,7 @@ const RadioWrapper = styled.div`
 
   > input + label {
     position: relative;
-    padding-left: 25px;
+    padding-left: 1.5rem;
     cursor: pointer;
 
     &::before {

--- a/src/components/Radio/tests/__snapshots__/index.js.snap
+++ b/src/components/Radio/tests/__snapshots__/index.js.snap
@@ -22,7 +22,7 @@ exports[`Radio renders correctly 1`] = `
 
 .c0 > input + label {
   position: relative;
-  padding-left: 25px;
+  padding-left: 1.5rem;
   cursor: pointer;
 }
 

--- a/src/components/TabNavigation/index.js
+++ b/src/components/TabNavigation/index.js
@@ -13,8 +13,8 @@ const Tab = styled.a`
   cursor: pointer;
   font-weight: ${fontWeights('light')};
   line-height: 2rem;
-  margin-right: 1em;
-  padding: 0 4px;
+  margin-right: 1rem;
+  padding: 0 0.25rem;
   text-decoration: none;
   transition: color 0.3s ease;
   ${ifProp(

--- a/src/components/TabNavigation/tests/__snapshots__/index.js.snap
+++ b/src/components/TabNavigation/tests/__snapshots__/index.js.snap
@@ -16,8 +16,8 @@ exports[`TabNavigation renders correctly 1`] = `
   cursor: pointer;
   font-weight: 300;
   line-height: 2rem;
-  margin-right: 1em;
-  padding: 0 4px;
+  margin-right: 1rem;
+  padding: 0 0.25rem;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: color 0.3s ease;

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -42,7 +42,7 @@ const TableRow = styled.tr`
 
 const TableCell = styled.td`
   font-size: ${fontSizes('medium')};
-  padding: 7px 1%;
+  padding: 0.4375rem 1%;
   vertical-align: middle;
   line-height: 30px;
   text-align: ${ifProp('alignRight', 'right', 'left')};
@@ -61,7 +61,7 @@ const TableCell = styled.td`
 `;
 
 const TableHeaderCell = styled.th`
-  padding: 16px 1%;
+  padding: 1rem 1%;
   font-weight: ${fontWeights('light')};
   font-size: ${fontSizes('small')};
   text-align: left;
@@ -69,7 +69,7 @@ const TableHeaderCell = styled.th`
 `;
 
 const ActionIcon = styled(Icon)`
-  padding: 2px;
+  padding: 0.125rem;
   cursor: pointer;
   transition: all 0.3s ease;
 

--- a/src/components/Table/tests/__snapshots__/index.js.snap
+++ b/src/components/Table/tests/__snapshots__/index.js.snap
@@ -164,7 +164,7 @@ exports[`Table renders correctly 1`] = `
 
 .c7 {
   font-size: 1rem;
-  padding: 7px 1%;
+  padding: 0.4375rem 1%;
   vertical-align: middle;
   line-height: 30px;
   text-align: left;
@@ -184,7 +184,7 @@ exports[`Table renders correctly 1`] = `
 
 .c8 {
   font-size: 1rem;
-  padding: 7px 1%;
+  padding: 0.4375rem 1%;
   vertical-align: middle;
   line-height: 30px;
   text-align: right;
@@ -203,7 +203,7 @@ exports[`Table renders correctly 1`] = `
 }
 
 .c2 {
-  padding: 16px 1%;
+  padding: 1rem 1%;
   font-weight: 300;
   font-size: 0.875rem;
   text-align: left;
@@ -213,7 +213,7 @@ exports[`Table renders correctly 1`] = `
 .c9 {
   display: inline-block;
   font-size: 1rem;
-  padding: 2px;
+  padding: 0.125rem;
   cursor: pointer;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;

--- a/src/components/UserMenu/UserMenuDropdown.js
+++ b/src/components/UserMenu/UserMenuDropdown.js
@@ -15,7 +15,7 @@ const Container = styled.div`
   display: inline-flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 18px 0;
+  padding: 1.125rem 0;
   position: absolute;
   right: 1%;
   top: 40px;
@@ -40,7 +40,7 @@ const Item = styled.a`
   font-weight: ${fontWeights('light')};
   letter-spacing: 0.02em;
   line-height: 2;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   text-decoration: none;
   transition: color 0.3s ease;
   white-space: nowrap;
@@ -54,15 +54,15 @@ const Item = styled.a`
 
 const ActionItem = styled(Item)`
   border-top: 1px solid ${uiColors('text.disabled')};
-  margin-top: 12px;
-  padding-top: 18px;
+  margin-top: 0.75rem;
+  padding-top: 1.125rem;
   ${ifProp(
     'smallSize',
     css`
       font-size: ${fontSizes('small')};
       border-top: none;
     `
-  )}
+  )};
 `;
 
 const ItemContainer = styled.div`
@@ -75,7 +75,7 @@ const ItemImage = styled.img`
   height: 30px;
   width: 30px;
   border-radius: 50%;
-  margin-left: 10px;
+  margin-left: 0.625rem;
 `;
 
 type MenuItem = {

--- a/src/elements/Accordion/AccordionFooter.js
+++ b/src/elements/Accordion/AccordionFooter.js
@@ -19,7 +19,7 @@ const AccordionFooterContainer = styled.footer`
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
-  padding: 16px 3%;
+  padding: 1rem 3%;
   background: ${colors.white};
   align-items: center;
   transition-timing-function: ease, ease;

--- a/src/elements/Accordion/AccordionPanel.js
+++ b/src/elements/Accordion/AccordionPanel.js
@@ -35,7 +35,7 @@ const AccordionPanelContainer = styled.div`
 const AccordionPanelHeader = styled.header`
   position: relative;
   margin: 0;
-  padding: 12px 3%;
+  padding: 0.75rem 3%;
   width: 100%;
   box-sizing: border-box;
   background: ${colors.white};
@@ -57,7 +57,7 @@ const AccordionIcon = styled(Icon)`
 `;
 
 const AccordionPanelDetails = styled.div`
-  padding: 10px 6% 26px;
+  padding: 0.625rem 6% 26px;
 `;
 
 type Props = {

--- a/src/elements/Accordion/tests/__snapshots__/index.js.snap
+++ b/src/elements/Accordion/tests/__snapshots__/index.js.snap
@@ -35,7 +35,7 @@ exports[`Accordion renders correctly 1`] = `
 .c2 {
   position: relative;
   margin: 0;
-  padding: 12px 3%;
+  padding: 0.75rem 3%;
   width: 100%;
   box-sizing: border-box;
   background: #fff;
@@ -59,7 +59,7 @@ exports[`Accordion renders correctly 1`] = `
 }
 
 .c6 {
-  padding: 10px 6% 26px;
+  padding: 0.625rem 6% 26px;
 }
 
 <div

--- a/src/elements/Button/ButtonWrapper.js
+++ b/src/elements/Button/ButtonWrapper.js
@@ -111,19 +111,19 @@ const ButtonWrapper = styled.button`
   ${switchProp('size', {
     xs: css`
       font-size: ${fontSizes('extraSmall')};
-      padding: 3px 4px;
+      padding: 0.1875rem 0.25rem;
     `,
     sm: css`
       font-size: ${fontSizes('small')};
-      padding: 6px 8px;
+      padding: 0.375rem 0.5rem;
     `,
     md: css`
       font-size: ${fontSizes('medium')};
-      padding: 9px 12px;
+      padding: 0.5625rem 0.75rem;
     `,
     lg: css`
       font-size: ${fontSizes('large')};
-      padding: 12px 16px;
+      padding: 0.75rem 1rem;
     `,
   })};
   ${applyStyleModifiers(modifiers)};

--- a/src/elements/Button/tests/__snapshots__/index.js.snap
+++ b/src/elements/Button/tests/__snapshots__/index.js.snap
@@ -31,7 +31,7 @@ exports[`Button renders correctly 1`] = `
   letter-spacing: 0.015em;
   line-height: 1;
   font-size: 1rem;
-  padding: 9px 12px;
+  padding: 0.5625rem 0.75rem;
 }
 
 .c0:hover {

--- a/src/elements/Card/index.js
+++ b/src/elements/Card/index.js
@@ -17,14 +17,14 @@ const CardWrapper = styled.div`
   line-height: 1.5;
   box-sizing: border-box;
   margin: 0;
-  padding: 0 24px;
+  padding: 0 1.5rem;
   list-style: none;
 `;
 
 const CardTitle = styled(Typography)`
   flex: 1;
   width: 100%;
-  padding: 16px;
+  padding: 1rem;
   margin: 0;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/elements/Card/tests/__snapshots__/index.js.snap
+++ b/src/elements/Card/tests/__snapshots__/index.js.snap
@@ -33,7 +33,7 @@ exports[`Card renders correctly 1`] = `
   line-height: 1.5;
   box-sizing: border-box;
   margin: 0;
-  padding: 0 24px;
+  padding: 0 1.5rem;
   list-style: none;
 }
 

--- a/src/elements/DatePicker/DateRangePickerWrapper.js
+++ b/src/elements/DatePicker/DateRangePickerWrapper.js
@@ -6,7 +6,7 @@ import DatePickerWrapper from '../DatePickerWrapper';
 const DateRangePickerWrapper = styled(DatePickerWrapper)`
   .datepreset {
     width: 96px;
-    padding: 64px 20px 10px;
+    padding: 3.75rem 1.25rem 0.625rem;
 
     label {
       display: block;
@@ -15,7 +15,7 @@ const DateRangePickerWrapper = styled(DatePickerWrapper)`
       transition: ease 200ms color;
       cursor: pointer;
       font-weight: ${fontWeights('light')};
-      padding: 7px;
+      padding: 0.4375rem;
 
       &:hover {
         color: ${uiColors('text.main')};
@@ -33,7 +33,7 @@ const DateRangePickerWrapper = styled(DatePickerWrapper)`
         border-right: 1px solid ${uiColors('primary.dark')};
         border-top: 1px solid ${uiColors('primary.dark')};
         transform: rotate(45deg);
-        margin-right: 8px;
+        margin-right: 0.5rem;
         position: relative;
         top: -2px;
       }

--- a/src/elements/DatePicker/tests/__snapshots__/index.js.snap
+++ b/src/elements/DatePicker/tests/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DatePicker renders correctly 1`] = `
 .c0 .PresetDateRangePicker_panel {
-  padding: 0 22px 11px;
+  padding: 0 1.375rem 0.6875rem;
 }
 
 .c0 .PresetDateRangePicker_button {
@@ -11,8 +11,8 @@ exports[`DatePicker renders correctly 1`] = `
   text-align: center;
   background: 0 0;
   color: #07AAE6;
-  padding: 4px 12px;
-  margin-right: 8px;
+  padding: 0.25rem 0.75rem;
+  margin-right: 0.5rem;
   font: inherit;
   font-weight: 700;
   line-height: normal;
@@ -34,7 +34,7 @@ exports[`DatePicker renders correctly 1`] = `
 }
 
 .c0 .CalendarDay {
-  padding: 1px;
+  padding: 0.0625rem;
   box-sizing: border-box;
   height: 37px;
   width: 37px;
@@ -154,8 +154,8 @@ exports[`DatePicker renders correctly 1`] = `
   color: #2A4D8E;
   font-size: 1.25rem;
   text-align: center;
-  padding-top: 20px;
-  padding-bottom: 48px;
+  padding-top: 1.25rem;
+  padding-bottom: 3.125rem;
   font-weight: 300 !important;
 }
 
@@ -164,8 +164,8 @@ exports[`DatePicker renders correctly 1`] = `
 }
 
 .c0 .CalendarMonth_caption__verticalScrollable {
-  padding-top: 12px;
-  padding-bottom: 7px;
+  padding-top: 0.75rem;
+  padding-bottom: 0.4375rem;
 }
 
 .c0 .CalendarMonthGrid {
@@ -258,7 +258,7 @@ exports[`DatePicker renders correctly 1`] = `
   top: 18px;
   line-height: 0.78;
   border-radius: 3px;
-  padding: 6px 9px;
+  padding: 0.375rem 0.5625rem;
 }
 
 .c0 .DayPickerNavigation_leftButton__horizontalDefault,
@@ -278,7 +278,7 @@ exports[`DatePicker renders correctly 1`] = `
 }
 
 .c0 .DayPickerNavigation_button__verticalDefault {
-  padding: 5px;
+  padding: 0.3125rem;
   background: #fff;
   box-shadow: 0 0 5px 2px rgba(0,0,0,0.1);
   position: relative;
@@ -297,13 +297,13 @@ exports[`DatePicker renders correctly 1`] = `
 }
 
 .c0 .DayPickerNavigation_rightButton__horizontalDefault:hover {
-  padding-left: 12px;
-  padding-right: 8px;
+  padding-left: 0.75rem;
+  padding-right: 0.5rem;
 }
 
 .c0 .DayPickerNavigation_leftButton__horizontalDefault:hover {
-  padding-right: 12px;
-  padding-left: 8px;
+  padding-right: 0.75rem;
+  padding-left: 0.5rem;
 }
 
 .c0 .DayPickerNavigation_svg__horizontal {
@@ -378,7 +378,7 @@ exports[`DatePicker renders correctly 1`] = `
   top: 62px;
   z-index: 2;
   text-align: left;
-  padding: 0 13px;
+  padding: 0 0.8125rem;
 }
 
 .c0 .DayPicker_weekHeader__vertical {
@@ -398,7 +398,7 @@ exports[`DatePicker renders correctly 1`] = `
 
 .c0 .DayPicker_weekHeader_ul {
   list-style: none;
-  margin: 1px 0;
+  margin: 0.0625rem 0;
   padding-left: 0;
   padding-right: 0;
   font-size: 1rem;
@@ -426,7 +426,7 @@ exports[`DatePicker renders correctly 1`] = `
 }
 
 .c0 .DayPicker_transitionContainer__verticalScrollable {
-  padding-top: 20px;
+  padding-top: 1.25rem;
   height: 100%;
   position: absolute;
   top: 0;
@@ -463,7 +463,7 @@ exports[`DatePicker renders correctly 1`] = `
   font-weight: 100;
   background-color: #fff;
   width: 100%;
-  padding: 0 5px;
+  padding: 0 0.3125rem;
   border: 0;
   border-top: 0;
   border-right: 0;
@@ -485,7 +485,7 @@ exports[`DatePicker renders correctly 1`] = `
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
   letter-spacing: 0.2px;
-  padding: 7px 7px 5px;
+  padding: 0.4375rem 0.4375rem 0.3125rem;
 }
 
 .c0 .DateInput_input__regular {
@@ -525,7 +525,7 @@ exports[`DatePicker renders correctly 1`] = `
 }
 
 .c0 .DateRangePickerInput {
-  padding: 5px 10px;
+  padding: 0.3125rem 0.625rem;
   box-sizing: border-box;
   background: #fff;
   border: 1px solid #d7dde5;
@@ -553,15 +553,15 @@ exports[`DatePicker renders correctly 1`] = `
 }
 
 .c0 .DateRangePickerInput__showClearDates {
-  padding-right: 30px;
+  padding-right: 1.875rem;
 }
 
 .c0 .DateRangePickerInput_arrow {
   display: inline-block;
   vertical-align: middle;
-  padding: 5px 10px;
+  padding: 0.3125rem 0.625rem;
   font-size: 0.875rem;
-  line-height: 16px;
+  line-height: 1rem;
   color: #aaadb4;
   font-weight: 300;
 }
@@ -609,7 +609,7 @@ exports[`DatePicker renders correctly 1`] = `
 
 .c0 .datepreset {
   width: 96px;
-  padding: 64px 20px 10px;
+  padding: 3.75rem 1.25rem 0.625rem;
 }
 
 .c0 .datepreset label {
@@ -620,7 +620,7 @@ exports[`DatePicker renders correctly 1`] = `
   transition: ease 200ms color;
   cursor: pointer;
   font-weight: 300;
-  padding: 7px;
+  padding: 0.4375rem;
 }
 
 .c0 .datepreset label:hover {
@@ -641,7 +641,7 @@ exports[`DatePicker renders correctly 1`] = `
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
-  margin-right: 8px;
+  margin-right: 0.5rem;
   position: relative;
   top: -2px;
 }

--- a/src/elements/DatePickerWrapper.js
+++ b/src/elements/DatePickerWrapper.js
@@ -6,7 +6,7 @@ import { uiColors, fontWeights, fontSizes } from 'utils';
 
 const DatePickerWrapper = styled.span`
   .PresetDateRangePicker_panel {
-    padding: 0 22px 11px;
+    padding: 0 1.375rem 0.6875rem;
   }
 
   .PresetDateRangePicker_button {
@@ -15,8 +15,8 @@ const DatePickerWrapper = styled.span`
     text-align: center;
     background: 0 0;
     color: ${uiColors('primary.main')};
-    padding: 4px 12px;
-    margin-right: 8px;
+    padding: 0.25rem 0.75rem;
+    margin-right: 0.5rem;
     font: inherit;
     font-weight: ${fontWeights('bold')};
     line-height: normal;
@@ -38,7 +38,7 @@ const DatePickerWrapper = styled.span`
   }
 
   .CalendarDay {
-    padding: 1px;
+    padding: 0.0625rem;
     box-sizing: border-box;
     height: 37px;
     width: 37px;
@@ -155,8 +155,8 @@ const DatePickerWrapper = styled.span`
     color: ${colors.navy};
     font-size: ${fontSizes('h6')};
     text-align: center;
-    padding-top: 20px;
-    padding-bottom: 48px;
+    padding-top: 1.25rem;
+    padding-bottom: 3.125rem;
     font-weight: ${fontWeights('light')} !important;
   }
 
@@ -165,8 +165,8 @@ const DatePickerWrapper = styled.span`
   }
 
   .CalendarMonth_caption__verticalScrollable {
-    padding-top: 12px;
-    padding-bottom: 7px;
+    padding-top: 0.75rem;
+    padding-bottom: 0.4375rem;
   }
 
   .CalendarMonthGrid {
@@ -256,7 +256,7 @@ const DatePickerWrapper = styled.span`
     top: 18px;
     line-height: 0.78;
     border-radius: 3px;
-    padding: 6px 9px;
+    padding: 0.375rem 0.5625rem;
   }
 
   .DayPickerNavigation_leftButton__horizontalDefault,
@@ -275,7 +275,7 @@ const DatePickerWrapper = styled.span`
   }
 
   .DayPickerNavigation_button__verticalDefault {
-    padding: 5px;
+    padding: 0.3125rem;
     background: ${colors.white};
     box-shadow: 0 0 5px 2px rgba(0, 0, 0, 0.1);
     position: relative;
@@ -294,13 +294,13 @@ const DatePickerWrapper = styled.span`
   }
 
   .DayPickerNavigation_rightButton__horizontalDefault:hover {
-    padding-left: 12px;
-    padding-right: 8px;
+    padding-left: 0.75rem;
+    padding-right: 0.5rem;
   }
 
   .DayPickerNavigation_leftButton__horizontalDefault:hover {
-    padding-right: 12px;
-    padding-left: 8px;
+    padding-right: 0.75rem;
+    padding-left: 0.5rem;
   }
 
   .DayPickerNavigation_svg__horizontal {
@@ -375,7 +375,7 @@ const DatePickerWrapper = styled.span`
     top: 62px;
     z-index: 2;
     text-align: left;
-    padding: 0 13px;
+    padding: 0 0.8125rem;
   }
 
   .DayPicker_weekHeader__vertical {
@@ -395,7 +395,7 @@ const DatePickerWrapper = styled.span`
 
   .DayPicker_weekHeader_ul {
     list-style: none;
-    margin: 1px 0;
+    margin: 0.0625rem 0;
     padding-left: 0;
     padding-right: 0;
     font-size: ${fontSizes('medium')};
@@ -422,7 +422,7 @@ const DatePickerWrapper = styled.span`
   }
 
   .DayPicker_transitionContainer__verticalScrollable {
-    padding-top: 20px;
+    padding-top: 1.25rem;
     height: 100%;
     position: absolute;
     top: 0;
@@ -459,7 +459,7 @@ const DatePickerWrapper = styled.span`
     font-weight: ${fontWeights('thin')};
     background-color: ${colors.white};
     width: 100%;
-    padding: 0 5px;
+    padding: 0 0.3125rem;
     border: 0;
     border-top: 0;
     border-right: 0;
@@ -478,7 +478,7 @@ const DatePickerWrapper = styled.span`
     font-size: ${fontSizes('small')};
     line-height: 18px;
     letter-spacing: 0.2px;
-    padding: 7px 7px 5px;
+    padding: 0.4375rem 0.4375rem 0.3125rem;
   }
 
   .DateInput_input__regular {
@@ -514,7 +514,7 @@ const DatePickerWrapper = styled.span`
   }
 
   .DateRangePickerInput {
-    padding: 5px 10px;
+    padding: 0.3125rem 0.625rem;
     box-sizing: border-box;
     background: ${colors.white};
     border: 1px solid ${colors.gray};
@@ -542,15 +542,15 @@ const DatePickerWrapper = styled.span`
   }
 
   .DateRangePickerInput__showClearDates {
-    padding-right: 30px;
+    padding-right: 1.875rem;
   }
 
   .DateRangePickerInput_arrow {
     display: inline-block;
     vertical-align: middle;
-    padding: 5px 10px;
+    padding: 0.3125rem 0.625rem;
     font-size: ${fontSizes('small')};
-    line-height: 16px;
+    line-height: 1rem;
     color: ${uiColors('text.light')};
     font-weight: ${fontWeights('light')};
   }

--- a/src/elements/Dropdown/index.js
+++ b/src/elements/Dropdown/index.js
@@ -16,7 +16,7 @@ const DropdownContainer = styled.select`
   font-size: ${fontSizes('small')};
   font-weight: ${fontWeights('light')};
   outline: none;
-  padding: 0.2em;
+  padding: 0.375rem 0.75rem;
   transition: all 0.3s ease;
 
   &:hover {

--- a/src/elements/Dropdown/tests/__snapshots__/index.js.snap
+++ b/src/elements/Dropdown/tests/__snapshots__/index.js.snap
@@ -10,7 +10,7 @@ exports[`Dropdown renders correctly 1`] = `
   font-size: 0.875rem;
   font-weight: 300;
   outline: none;
-  padding: 0.2em;
+  padding: 0.375rem 0.75rem;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
 }

--- a/src/elements/Input/index.js
+++ b/src/elements/Input/index.js
@@ -18,7 +18,7 @@ const StyledInput = styled.input`
   background: ${colors.white};
   font-weight: ${fontWeights('light')};
   border: 1px solid ${colors.gray};
-  padding: 10px 18px 11px;
+  padding: 0.375rem 0.75rem;
   border-radius: 3px;
   font-size: ${fontSizes('medium')};
   line-height: 1;

--- a/src/elements/Input/tests/__snapshots__/index.js.snap
+++ b/src/elements/Input/tests/__snapshots__/index.js.snap
@@ -13,7 +13,7 @@ exports[`undefined renders correctly 1`] = `
   background: #fff;
   font-weight: 300;
   border: 1px solid #d7dde5;
-  padding: 10px 18px 11px;
+  padding: 0.375rem 0.75rem;
   border-radius: 3px;
   font-size: 1rem;
   line-height: 1;

--- a/src/elements/Notification/NotificationContainer.js
+++ b/src/elements/Notification/NotificationContainer.js
@@ -26,7 +26,7 @@ const NotificationContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 18px 2%;
+  padding: 1.125rem 2%;
   min-height: 10%;
   left: 15%;
   right: 15%;
@@ -64,7 +64,7 @@ const NotificationContainer = styled.div`
   })};
 
   i {
-    margin-right: 12px;
+    margin-right: 0.75rem;
     position: relative;
     top: 2px;
   }

--- a/src/elements/Notification/tests/__snapshots__/index.js.snap
+++ b/src/elements/Notification/tests/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`Notification renders correctly 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 18px 2%;
+  padding: 1.125rem 2%;
   min-height: 10%;
   left: 15%;
   right: 15%;
@@ -33,7 +33,7 @@ exports[`Notification renders correctly 1`] = `
 }
 
 .c0 i {
-  margin-right: 12px;
+  margin-right: 0.75rem;
   position: relative;
   top: 2px;
 }

--- a/src/elements/Pagination/PaginationWrapper.js
+++ b/src/elements/Pagination/PaginationWrapper.js
@@ -15,7 +15,7 @@ const PaginationWrapper = styled.div`
   vertical-align: top;
   cursor: pointer;
   display: inline-flex;
-  margin: 14px auto;
+  margin: 1rem auto;
 
   ul {
     padding-inline-start: 0;
@@ -29,7 +29,7 @@ const PaginationWrapper = styled.div`
 
     a {
       color: ${uiColors('text.light')};
-      padding: 1px 8px 1px;
+      padding: 0.0625rem 1rem 0.0625rem;
 
       &:focus {
         outline: none;
@@ -59,11 +59,11 @@ const PaginationWrapper = styled.div`
 
       a {
         color: ${uiColors('text.light')};
-        padding: 1px 16px 1px;
+        padding: 0.0625rem 1rem 0.0625rem;
 
         &::before {
           content: '⟵';
-          padding-right: 8px;
+          padding-right: 0.5rem;
           position: relative;
           top: -1px;
           left: 0;
@@ -77,11 +77,11 @@ const PaginationWrapper = styled.div`
 
       a {
         color: ${uiColors('text.light')};
-        padding: 1px 16px 1px;
+        padding: 0.0625rem 1rem 0.0625rem;
 
         &::after {
           content: '⟶';
-          padding-left: 8px;
+          padding-left: 0.5rem;
           position: relative;
           top: -1px;
           right: 0;

--- a/src/elements/Pagination/tests/__snapshots__/index.js.snap
+++ b/src/elements/Pagination/tests/__snapshots__/index.js.snap
@@ -15,7 +15,7 @@ exports[`Pagination renders correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  margin: 14px auto;
+  margin: 1rem auto;
 }
 
 .c1 ul {
@@ -35,7 +35,7 @@ exports[`Pagination renders correctly 1`] = `
 
 .c1 li a {
   color: #aaadb4;
-  padding: 1px 8px 1px;
+  padding: 0.0625rem 1rem 0.0625rem;
 }
 
 .c1 li a:focus {
@@ -65,12 +65,12 @@ exports[`Pagination renders correctly 1`] = `
 
 .c1 li.previous a {
   color: #aaadb4;
-  padding: 1px 16px 1px;
+  padding: 0.0625rem 1rem 0.0625rem;
 }
 
 .c1 li.previous a::before {
   content: '⟵';
-  padding-right: 8px;
+  padding-right: 0.5rem;
   position: relative;
   top: -1px;
   left: 0;
@@ -84,12 +84,12 @@ exports[`Pagination renders correctly 1`] = `
 
 .c1 li.next a {
   color: #aaadb4;
-  padding: 1px 16px 1px;
+  padding: 0.0625rem 1rem 0.0625rem;
 }
 
 .c1 li.next a::after {
   content: '⟶';
-  padding-left: 8px;
+  padding-left: 0.5rem;
   position: relative;
   top: -1px;
   right: 0;

--- a/src/elements/PillLabel/index.js
+++ b/src/elements/PillLabel/index.js
@@ -48,19 +48,19 @@ const PillLabel = styled.span`
   ${switchProp('size', {
     xs: css`
       font-size: ${fontSizes('extraSmall')};
-      padding: 3px 4px;
+      padding: 0.1875rem 0.25rem;
     `,
     sm: css`
       font-size: ${fontSizes('small')};
-      padding: 6px 8px;
+      padding: 0.375rem 0.5rem;
     `,
     md: css`
       font-size: ${fontSizes('medium')};
-      padding: 9px 12px;
+      padding: 0.5625rem 0.75rem;
     `,
     lg: css`
       font-size: ${fontSizes('large')};
-      padding: 12px 16px;
+      padding: 0.75rem 1rem;
     `,
   })};
   ${applyStyleModifiers(modifiers)};

--- a/src/elements/PillLabel/tests/__snapshots__/index.js.snap
+++ b/src/elements/PillLabel/tests/__snapshots__/index.js.snap
@@ -17,7 +17,7 @@ exports[`PillLabel renders correctly 1`] = `
   letter-spacing: 0.015em;
   line-height: 1;
   font-size: 1rem;
-  padding: 9px 12px;
+  padding: 0.5625rem 0.75rem;
 }
 
 <span

--- a/src/elements/SingleDayPicker/SingleDayPickerWrapper.js
+++ b/src/elements/SingleDayPicker/SingleDayPickerWrapper.js
@@ -42,7 +42,7 @@ const SingleDatePickerWrapper = styled(DatePickerWrapper)`
   }
 
   .SingleDatePickerInput__showClearDate {
-    padding-right: 30px;
+    padding-right: 1.875rem;
   }
 
   .SingleDatePickerInput_calendarIcon {
@@ -55,8 +55,8 @@ const SingleDatePickerWrapper = styled(DatePickerWrapper)`
     cursor: pointer;
     display: inline-block;
     vertical-align: middle;
-    padding: 10px;
-    margin: 0 5px 0 10px;
+    padding: 0.625rem;
+    margin: 0 0.5rem;
   }
 
   .SingleDatePickerInput_calendarIcon_svg {

--- a/src/elements/Switch/SwitchWrapper.js
+++ b/src/elements/Switch/SwitchWrapper.js
@@ -46,7 +46,7 @@ const SwitchWrapper = styled.span`
     border: 0;
     clip: rect(0 0 0 0);
     height: 1px;
-    margin: -1px;
+    margin: -0.0625rem;
     overflow: hidden;
     padding: 0;
     position: absolute;

--- a/src/elements/Switch/tests/__snapshots__/index.js.snap
+++ b/src/elements/Switch/tests/__snapshots__/index.js.snap
@@ -60,7 +60,7 @@ exports[`Switch renders correctly 1`] = `
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
-  margin: -1px;
+  margin: -0.0625rem;
   overflow: hidden;
   padding: 0;
   position: absolute;

--- a/src/elements/TextArea/index.js
+++ b/src/elements/TextArea/index.js
@@ -19,8 +19,8 @@ const TextArea = styled.textarea`
   min-width: 260px;
   max-width: 560px;
   width: 100%;
-  margin: 6px 0;
-  padding: 12px 18px;
+  margin: 0.5rem 0;
+  padding: 0.75rem 1.125rem;
 
   &:focus {
     border-bottom: 1px solid ${uiColors('primary.main')};

--- a/src/elements/TextArea/tests/__snapshots__/index.js.snap
+++ b/src/elements/TextArea/tests/__snapshots__/index.js.snap
@@ -19,8 +19,8 @@ exports[`TextArea renders correctly 1`] = `
   min-width: 260px;
   max-width: 560px;
   width: 100%;
-  margin: 6px 0;
-  padding: 12px 18px;
+  margin: 0.5rem 0;
+  padding: 0.75rem 1.125rem;
 }
 
 .c0:focus {


### PR DESCRIPTION
## OVERVIEW

- Use same padding sizes for Input and Dropdown
- Use rem unit for spacing through out the app

## WHERE SHOULD THE REVIEWER START?

- _`/src/elements/Input.js`_
- _`/src/elements/Dropdown.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
