### PR TITLE
No issue/feature/button link modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-# [0.11.2] - 25-03-2019
+# [0.12.0] - 25-03-2019
 
 ### Added
 
 - Add Input sizes (xs, sm, md, lg)
+- Add Button buttonLink modifier
 
 ### Fixes
 

--- a/src/elements/Button/ButtonWrapper.js
+++ b/src/elements/Button/ButtonWrapper.js
@@ -84,6 +84,23 @@ const modifiers = {
       border-color: ${colors.green};
     }
   `,
+  buttonLink: ({ theme }) => `
+  color: ${theme.palette.primary.main};
+  border: none;
+  background: transparent;
+  display: inline;
+
+  &:hover, &:focus {
+    color: ${theme.palette.primary.dark};
+  }
+
+  &:disabled {
+    background: transparent;
+    background-color: transparent;
+    font-style: italic;
+    cursor: not-allowed;
+  }
+  `,
 };
 
 const ButtonWrapper = styled.button`

--- a/src/elements/Button/Readme.md
+++ b/src/elements/Button/Readme.md
@@ -42,6 +42,7 @@ function Page(props) {
   <Button buttonModifiers={['buttonWarning']}>Button Warning</Button> <br />
   <Button buttonModifiers={['buttonSuccess']}>Button Success</Button> <br />
   <Button buttonModifiers={['buttonDanger']}>Button Danger</Button> <br />
+  <Button buttonModifiers={['buttonLink']}>Button Link</Button> <br />
   <Button disabled>Button Disabled</Button>
 </div>
 ```

--- a/src/elements/Button/Readme.md
+++ b/src/elements/Button/Readme.md
@@ -42,8 +42,8 @@ function Page(props) {
   <Button buttonModifiers={['buttonWarning']}>Button Warning</Button> <br />
   <Button buttonModifiers={['buttonSuccess']}>Button Success</Button> <br />
   <Button buttonModifiers={['buttonDanger']}>Button Danger</Button> <br />
-  <Button buttonModifiers={['buttonLink']}>Button Link</Button> <br />
-  <Button disabled>Button Disabled</Button>
+  <Button disabled>Button Disabled</Button> <br />
+  <Button buttonModifiers={['buttonLink']}>Button Link</Button>
 </div>
 ```
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -300,11 +300,22 @@ type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 export interface ButtonContentProps {
   icon?: string;
   iconPosition?: string;
-  iconModifiers?: Array<string>;
+  iconModifiers?: Array<IconModifier>;
 }
 
+type ButtonModifier =
+  | 'hoverInfo'
+  | 'hoverDanger'
+  | 'hoverWarning'
+  | 'hoverSuccess'
+  | 'buttonPrimary'
+  | 'buttonInfo'
+  | 'buttonDanger'
+  | 'buttonSuccess'
+  | 'buttonLink';
+
 export interface ButtonProps<T> extends ButtonHTMLAttributes<HTMLButtonElement>, ButtonContentProps {
-  buttonModifiers?: Array<string>;
+  buttonModifiers?: Array<ButtonModifier>;
   size?: ButtonSize;
   style?: CSSProperties;
   className?: string;


### PR DESCRIPTION
## OVERVIEW

Adds a buttonLink modifier to the Button which styles the button as a link but without the need of a href prop.

## WHERE SHOULD THE REVIEWER START?

`/src/elements/Button/ButtonWrapper.js`

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
