### PR TITLE
Enable Button to accept custom Icon as prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.13.0] - 28-03-2019
+
+### Added
+
+- Add Custom Icon to Button as prop
+
 # [0.12.0] - 25-03-2019
 
 ### Added

--- a/src/elements/Button/Readme.md
+++ b/src/elements/Button/Readme.md
@@ -68,5 +68,12 @@ function Page(props) {
   >
     Button with Icon Color Modifier
   </Button>
+  <br />
+  <Button
+    iconModifiers={['statusColorWarning']}
+    icon={<InPlayerIcon name="download"     iconModifiers={['statusColorWarning']} modifiers={['statusColorSuccess']} />}
+  >
+    Button with Custom Icon
+  </Button>
 </div>
 ```

--- a/src/elements/Button/Readme.md
+++ b/src/elements/Button/Readme.md
@@ -69,10 +69,7 @@ function Page(props) {
     Button with Icon Color Modifier
   </Button>
   <br />
-  <Button
-    iconModifiers={['statusColorWarning']}
-    icon={<InPlayerIcon name="download"     iconModifiers={['statusColorWarning']} modifiers={['statusColorSuccess']} />}
-  >
+  <Button icon={<InPlayerIcon name="download" />}>
     Button with Custom Icon
   </Button>
 </div>

--- a/src/elements/Button/index.js
+++ b/src/elements/Button/index.js
@@ -7,7 +7,7 @@ import ButtonWrapper from './ButtonWrapper';
 type Size = 'xs' | 'sm' | 'md' | 'lg';
 
 type ContentProps = {
-  icon?: string,
+  icon?: string | Node,
   iconPosition?: string,
   iconModifiers?: Array<string>,
   children: Node,
@@ -25,18 +25,22 @@ const ContentHolder = styled.span`
   padding: 0.2rem;
 `;
 
-const Content = ({ icon, iconPosition, iconModifiers, children }: ContentProps) =>
-  iconPosition === 'right' ? (
+const Content = ({ icon, iconPosition, iconModifiers, children }: ContentProps) => {
+  const iconContent =
+    typeof icon === 'string' ? <Icon name={icon} modifiers={iconModifiers} /> : icon;
+
+  return iconPosition === 'right' ? (
     <>
       {children && <ContentHolder>{children}</ContentHolder>}
-      {icon && <Icon name={icon} modifiers={iconModifiers} />}
+      {icon && iconContent}
     </>
   ) : (
     <>
-      {icon && <Icon name={icon} modifiers={iconModifiers} />}
+      {icon && iconContent}
       {children && <ContentHolder>{children}</ContentHolder>}
     </>
   );
+};
 
 Content.defaultProps = {
   icon: null,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -140,7 +140,7 @@ export declare class Navbar extends Component<NavbarProps, NavbarState> {
 
 export type NavbarMenuItemProps = Navbar$MenuItemProps;
 
-type NoteType = 'informative' | 'success' | 'warning' | 'danger';
+export type NoteType = 'informative' | 'success' | 'warning' | 'danger';
 
 export interface NoteProps {
   title: string;
@@ -260,7 +260,7 @@ interface TabsProps {
 
 export declare const Tabs: FunctionComponent<TabsProps>;
 
-type TooltipVariant = 'up' | 'down' | 'left' | 'right';
+export type TooltipVariant = 'up' | 'down' | 'left' | 'right';
 
 interface TooltipProps {
   placement: TooltipVariant;
@@ -295,15 +295,15 @@ export declare class Accordion extends Component<AccordionProps, AccordionState>
   toggleClose: (name: string, accordionAction: () => any) => (saveOnClose: boolean) => any;
 }
 
-type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
+export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export interface ButtonContentProps {
-  icon?: string;
+  icon?: string | ReactNode;
   iconPosition?: string;
   iconModifiers?: Array<IconModifier>;
 }
 
-type ButtonModifier =
+export type ButtonModifier =
   | 'hoverInfo'
   | 'hoverDanger'
   | 'hoverWarning'
@@ -369,7 +369,7 @@ declare const THIS_MONTH = 'this month';
 declare const LAST_MONTH = 'last month';
 declare const THIS_YEAR = 'this year';
 
-type Period = 'this week' | 'last week' | 'this month' | 'last month' | 'this year';
+export type Period = 'this week' | 'last week' | 'this month' | 'last month' | 'this year';
 
 export declare class DatePicker extends Component<DatePickerProps, DatePickerState> {
   onFocusedInputChange: (focusedInput: string) => void;
@@ -432,7 +432,7 @@ export interface LoaderProps {
 
 export declare const Loader: StyledComponent<'div', Theme, LoaderProps>;
 
-type NotificationVariant = 'success' | 'danger' | 'warning';
+export type NotificationVariant = 'success' | 'danger' | 'warning';
 
 interface NotificationProps {
   title: string;
@@ -482,9 +482,9 @@ export interface PaginationProps {
 
 export declare const Pagination: FunctionComponent<PaginationProps>;
 
-type PillLabelModifier = 'primary' | 'info' | 'success' | 'danger' | 'warning';
+export type PillLabelModifier = 'primary' | 'info' | 'success' | 'danger' | 'warning';
 
-type PillLabelSize = 'xs' | 'sm' | 'md' | 'lg';
+export type PillLabelSize = 'xs' | 'sm' | 'md' | 'lg';
 
 interface PillLabelProps {
   modifiers?: Array<PillLabelModifier>;
@@ -493,7 +493,7 @@ interface PillLabelProps {
 
 export declare const PillLabel: StyledComponent<'span', Theme, PillLabelProps>;
 
-type ProgressType = 'circle' | 'line';
+export type ProgressType = 'circle' | 'line';
 
 export interface ProgressProps {
   type?: ProgressType;
@@ -541,7 +541,7 @@ export declare const Switch: FunctionComponent<SwitchProps>;
 
 export declare const TextArea: StyledComponent<'input', Theme>;
 
-type InputSize = 'xs' | 'sm' | 'md' | 'lg';
+export type InputSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export interface InputProps extends AllHTMLAttributes<HTMLInputElement> {
   ref?: Ref<HTMLInputElement>;
@@ -550,9 +550,9 @@ export interface InputProps extends AllHTMLAttributes<HTMLInputElement> {
 
 export declare const Input: ForwardRefExoticComponent<InputProps>;
 
-type TypographyVariant = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+export type TypographyVariant = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
 
-type TypographyModifier = 'textPrimary' | 'textDanger' | 'textSuccess' | 'textWarning';
+export type TypographyModifier = 'textPrimary' | 'textDanger' | 'textSuccess' | 'textWarning';
 
 export interface TypographyProps {
   variant: TypographyVariant;


### PR DESCRIPTION
## OVERVIEW

_Enable Button to accept custom Icon as prop._

## WHERE SHOULD THE REVIEWER START?

`/src/elements/Button.js`

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide._

## ANY NEW DEPENDENCIES ADDED?

_None._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

![btn-custom-icon](https://user-images.githubusercontent.com/16154503/55161746-8916d600-5166-11e9-9cb3-1954aa37a2a3.png)

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
