### PR TITLE
210/Change: Make DatePicker elements endDate prop optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 =======
-# [0.15.2] - 15-05-2019
+# [0.15.2] - 16-05-2019
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 =======
+# [0.15.2] - 15-05-2019
+
+### Fixes
+
+- Make endDate prop optional in DatePicker component
 
 # [0.15.1] - 15-05-2019
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest src/** --watch",
     "test:watchAll": "jest src/** --watchAll",
     "test:coverage:report": "open ./coverage/lcov-report/index.html",
-    "test:update:snapshots": "jest src/** --updateSnapshot",
+    "test:update-snapshots": "jest src/** --updateSnapshot",
     "flow": "flow",
     "flow:watch": "flow-watch",
     "generate:docs": "yarn styleguide:build && git add docs && git commit --amend --no-edit"

--- a/src/elements/DatePicker/index.js
+++ b/src/elements/DatePicker/index.js
@@ -15,7 +15,7 @@ const THIS_YEAR = 'this year';
 
 type Props = {
   startDate: Moment,
-  endDate: Moment,
+  endDate?: Moment,
   startDateId?: string,
   endDateId?: string,
   calendarInfo?: boolean,
@@ -112,6 +112,7 @@ class DatePicker extends React.Component<Props> {
 }
 
 DatePicker.defaultProps = {
+  endDate: null,
   startDateId: 'startDate',
   endDateId: 'endDate',
   calendarInfo: false,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -376,7 +376,7 @@ export type DatePicker$OnFocusChange = (focusedInput: FocusedInputShape | null) 
 
 export interface DatePickerProps {
   startDate: Moment;
-  endDate: Moment;
+  endDate?: Moment;
   startDateId?: string;
   endDateId?: string;
   calendarInfo?: boolean;


### PR DESCRIPTION
## OVERVIEW

_Made endDate optional prop on DatePicker element_

## WHERE SHOULD THE REVIEWER START?

_`src/elements/DatePicker/index.js`_
_`src/index.d.ts`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
