### PR TITLE
Use svg background image for Dropdown arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- Use svg background image for Dropdown arrow
+
+# [0.19.2] - 02-07-2019
+
+### Fixes
+
 - Style Dropdown consistently across browsers
 
 # [0.19.1] - 01-07-2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 =======
 
-# [0.19.2] - 02-07-2019
+# [0.19.3] - 03-07-2019
 
 ### Fixes
 

--- a/src/elements/Dropdown/index.js
+++ b/src/elements/Dropdown/index.js
@@ -9,23 +9,20 @@ import colors from 'config/colors';
 
 const DropdownContainer = styled.select`
   border: thin solid ${colors.gray};
-  border-radius: 4px;
+  border-radius: 0.188em;
   color: ${uiColors('text.light')};
   cursor: pointer;
   font-size: ${fontSizes('small')};
   font-weight: ${fontWeights('light')};
   outline: none;
   transition: all 0.3s ease;
-  padding: 0.5rem 3.5rem 0.5rem 1rem;
+  padding: 0.6em 1.8em 0.5em 0.8em;
   line-height: 1.5em;
   background-color: ${colors.white};
+  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 140 140' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><g><path d='m121.3,34.6c-1.6-1.6-4.2-1.6-5.8,0l-51,51.1-51.1-51.1c-1.6-1.6-4.2-1.6-5.8,0-1.6,1.6-1.6,4.2 0,5.8l53.9,53.9c0.8,0.8 1.8,1.2 2.9,1.2 1,0 2.1-0.4 2.9-1.2l53.9-53.9c1.7-1.6 1.7-4.2 0.1-5.8z' fill='grey'/></g></svg>");
   background-repeat: no-repeat;
-  background-size: 5px 5px, 5px 5px, 1px 1.5rem;
-  /* stylelint-disable value-list-comma-newline-after */
-  background-image: linear-gradient(45deg, transparent 50%, gray 50%),
-    linear-gradient(135deg, gray 50%, transparent 50%), linear-gradient(to right, #ccc, #ccc);
-  background-position: calc(100% - 1.25rem) calc(1rem + 0.125rem),
-    calc(100% - 0.9375rem) calc(1rem + 0.125rem), calc(100% - 2.5rem) 0.5rem;
+  background-position: right 0.7em top 50%, 0 0;
+  background-size: 0.65em auto, 100%;
 
   /* reset browser default styling  */
   margin: 0;

--- a/src/elements/Input/index.js
+++ b/src/elements/Input/index.js
@@ -18,9 +18,9 @@ const StyledInput = styled.input`
   transition: all ease 300ms;
   background: ${colors.white};
   font-weight: ${fontWeights('light')};
-  border: 1px solid ${colors.gray};
-  padding: 0.375rem 0.75rem;
-  border-radius: 3px;
+  padding: 0.375em 0.75em;
+  border: thin solid ${colors.gray};
+  border-radius: 0.188em;
   font-size: ${fontSizes('medium')};
   line-height: 1;
 

--- a/src/elements/Input/tests/__snapshots__/index.js.snap
+++ b/src/elements/Input/tests/__snapshots__/index.js.snap
@@ -12,9 +12,9 @@ exports[`Input renders correctly 1`] = `
   transition: all ease 300ms;
   background: #fff;
   font-weight: 300;
-  border: 1px solid #d7dde5;
-  padding: 0.375rem 0.75rem;
-  border-radius: 3px;
+  padding: 0.375em 0.75em;
+  border: thin solid #d7dde5;
+  border-radius: 0.188em;
   font-size: 1rem;
   line-height: 1;
   font-size: 1rem;


### PR DESCRIPTION
## OVERVIEW

_Use svg background image for Dropdown arrow._

## WHERE SHOULD THE REVIEWER START?

_`/src/elements/Dropdown.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
