### PR TITLE
Accordion footer z-index change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 =======
-# [0.19.4] - 03-07-2019
-
-### Change
-
-- Change accordion footer z-index
-
 # [0.19.3] - 03-07-2019
 
 ### Fixes
 
 - Use svg background image for Dropdown arrow
+
+### Change
+
+- Change accordion footer z-index
 
 # [0.19.2] - 02-07-2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 =======
+# [0.19.4] - 03-07-2019
+
+### Change
+
+- Change accordion footer z-index
 
 # [0.19.3] - 03-07-2019
 

--- a/src/elements/Accordion/AccordionFooter.js
+++ b/src/elements/Accordion/AccordionFooter.js
@@ -25,7 +25,7 @@ const AccordionFooterContainer = styled.footer`
   transition-duration: 400ms, 1000ms;
   transition-property: all, background;
   transition-delay: 0s, 300ms;
-  z-index: ${ifProp('isActive', '40', '10')};
+  z-index: ${ifProp('isActive', '25', '10')};
   border-top: 1px solid ${colors.gray};
   border-bottom: 1px solid ${colors.gray};
 `;

--- a/src/elements/Progress/tests/__snapshots__/index.js.snap
+++ b/src/elements/Progress/tests/__snapshots__/index.js.snap
@@ -9,8 +9,8 @@ exports[`Progress renders correctly 1`] = `
   <path
     className="rc-progress-circle-trail"
     d="M 50,50 m 0,-49.5
-   a 49.5,49.5 0 1 1 0,99
-   a 49.5,49.5 0 1 1 0,-99"
+     a 49.5,49.5 0 1 1 0,99
+     a 49.5,49.5 0 1 1 0,-99"
     fillOpacity="0"
     stroke="#d7dde5"
     strokeLinecap="round"
@@ -27,10 +27,9 @@ exports[`Progress renders correctly 1`] = `
   <path
     className="rc-progress-circle-path"
     d="M 50,50 m 0,-49.5
-   a 49.5,49.5 0 1 1 0,99
-   a 49.5,49.5 0 1 1 0,-99"
+     a 49.5,49.5 0 1 1 0,99
+     a 49.5,49.5 0 1 1 0,-99"
     fillOpacity="0"
-    stroke=""
     strokeLinecap="round"
     strokeWidth={0}
     style={


### PR DESCRIPTION
## OVERVIEW

_Set accordion footer z-index to 25_

## WHERE SHOULD THE REVIEWER START?

_`/src/elements/Accordion/AccordionFooter.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
