### PR TITLE
Missing optional prop disabled in Checkbox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 =======
+# [0.23.1] - 19-07-2019
+
+### Fixes
+
+- Add missing optional prop disabled to Checkbox component
 
 # [0.23.0] - 19-07-2019
 

--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -13,6 +13,7 @@ type Props = {
   /** A className can be passed down for further styling or extending with CSS-in-JS */
   className?: string,
   style?: Object,
+  disabled?: boolean,
 };
 
 const Checkbox = ({ label, id, onChange, containerRef, className, style, ...rest }: Props) => {
@@ -30,6 +31,7 @@ Checkbox.defaultProps = {
   className: '',
   style: {},
   containerRef: null,
+  disabled: false,
 };
 
 export default Checkbox;

--- a/src/components/Checkbox/tests/__snapshots__/index.js.snap
+++ b/src/components/Checkbox/tests/__snapshots__/index.js.snap
@@ -135,6 +135,7 @@ exports[`Checkbox renders correctly 1`] = `
   style={Object {}}
 >
   <input
+    disabled={false}
     onChange={[Function]}
     type="checkbox"
   />

--- a/src/components/Table/tests/__snapshots__/index.js.snap
+++ b/src/components/Table/tests/__snapshots__/index.js.snap
@@ -247,6 +247,7 @@ exports[`Table renders correctly 1`] = `
         >
           <input
             checked={false}
+            disabled={false}
             id="toggleAll"
             onChange={[Function]}
             type="checkbox"
@@ -281,6 +282,7 @@ exports[`Table renders correctly 1`] = `
           style={Object {}}
         >
           <input
+            disabled={false}
             onChange={[Function]}
             type="checkbox"
           />

--- a/src/elements/Progress/tests/__snapshots__/index.js.snap
+++ b/src/elements/Progress/tests/__snapshots__/index.js.snap
@@ -9,8 +9,8 @@ exports[`Progress renders correctly 1`] = `
   <path
     className="rc-progress-circle-trail"
     d="M 50,50 m 0,-49.5
-   a 49.5,49.5 0 1 1 0,99
-   a 49.5,49.5 0 1 1 0,-99"
+     a 49.5,49.5 0 1 1 0,99
+     a 49.5,49.5 0 1 1 0,-99"
     fillOpacity="0"
     stroke="#d7dde5"
     strokeLinecap="round"
@@ -27,10 +27,9 @@ exports[`Progress renders correctly 1`] = `
   <path
     className="rc-progress-circle-path"
     d="M 50,50 m 0,-49.5
-   a 49.5,49.5 0 1 1 0,99
-   a 49.5,49.5 0 1 1 0,-99"
+     a 49.5,49.5 0 1 1 0,99
+     a 49.5,49.5 0 1 1 0,-99"
     fillOpacity="0"
-    stroke=""
     strokeLinecap="round"
     strokeWidth={0}
     style={

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,6 +62,7 @@ export interface CheckboxProps {
   containerRef?: React.RefObject<HTMLDivElement>;
   className?: string;
   style?: CSSProperties;
+  disabled?: boolean;
 }
 
 export declare const Checkbox: FunctionComponent<CheckboxProps>;


### PR DESCRIPTION
## OVERVIEW

_Add missing optional prop disabled to Checkbox component._

## WHERE SHOULD THE REVIEWER START?

_`/src/components/Checkbox/index.js`_
_`/src/index.d.ts`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
