### PR TITLE
Add disabled and iconTooltip options to Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
-- Add private AccordionPanel prop 'otherPanelIsActive' to prevent icon rendering
+- Add private AccordionPanel prop 'isOtherPanelActive' to prevent icon rendering
   by an inactive AccordionPanel while another AccordionPanel is active
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 =======
-# [0.23.2] - 26-07-2019
+# [0.24.0] - 26-07-2019
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 
 =======
+# [0.23.2] - 26-07-2019
+
+### Fixes
+
+- Add private AccordionPanel prop 'otherPanelIsActive' to prevent icon rendering
+  by an inactive AccordionPanel while another AccordionPanel is active
+
+### Change
+
+- Add and implement public AccordionPanel props 'disabled' and 'iconTooltip'
+
 # [0.23.1] - 19-07-2019
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 =======
+
 # [0.24.0] - 26-07-2019
 
 ### Fixes

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -10,7 +10,7 @@ import type { FadeEasing } from './Tooltip';
 export type Placement = 'left' | 'right' | 'top' | 'bottom';
 export type TooltipBehavior = 'hover' | 'click' | 'ref';
 
-type Props = {
+export type Props = {
   behavior?: TooltipBehavior,
   durationOnClick?: number,
   arrowWidth?: number,

--- a/src/elements/Accordion/AccordionPanel.js
+++ b/src/elements/Accordion/AccordionPanel.js
@@ -8,6 +8,7 @@ import { uiColors, fontWeights } from 'utils';
 // Components
 import Icon from 'elements/Icon';
 import Typography from 'elements/Typography';
+import Tooltip, { Props as TooltipProps } from 'components/Tooltip';
 
 const AccordionPanelContainer = styled.div`
   width: 100%;
@@ -38,7 +39,8 @@ const AccordionPanelHeader = styled.header`
   padding: 1rem 3%;
   width: 100%;
   box-sizing: border-box;
-  background: ${colors.white};
+  background: ${ifProp('disabled', colors.lightGray, colors.white)};
+  cursor: ${({ disabled, isActive }) => (disabled || isActive ? 'default' : 'pointer')};
   border-bottom: 1px solid ${colors.lightGray};
   display: flex;
   justify-content: space-between;
@@ -54,14 +56,14 @@ const AccordionPanelHeader = styled.header`
 
 const AccordionTitle = styled(Typography)`
   font-weight: ${fontWeights('thin')};
-  color: ${uiColors('text.main')};
+  color: ${ifProp('disabled', uiColors('text.disabled'), uiColors('text.main'))};
   margin: 0;
-  cursor: ${ifProp('isActive', 'default', 'pointer')};
   display: inline;
 `;
 
 const AccordionIcon = styled(Icon)`
   color: ${uiColors('primary.main')};
+  ${({ pointer }) => (pointer ? 'cursor: pointer;' : '')}
 `;
 
 const AccordionPanelDetails = styled.div`
@@ -71,26 +73,43 @@ const AccordionPanelDetails = styled.div`
 type Props = {
   label: string,
   isActive: boolean,
+  otherPanelIsActive: boolean,
   icon?: string,
+  iconTooltip?: TooltipProps,
   contentHeight: string,
   openPanel: (name: string) => boolean,
   renderContent: () => any,
+  disabled: boolean,
 };
 
 const AccordionPanel = ({
   openPanel,
   label,
   isActive,
+  otherPanelIsActive,
   icon,
+  iconTooltip,
   renderContent,
   contentHeight,
+  disabled,
 }: Props) => (
   <>
-    <AccordionPanelHeader onClick={openPanel} isActive={isActive}>
-      <AccordionTitle variant="h6" isActive={isActive}>
+    <AccordionPanelHeader
+      disabled={disabled}
+      onClick={!disabled ? openPanel : null}
+      isActive={isActive}
+    >
+      <AccordionTitle variant="h6" isActive={isActive} disabled={disabled}>
         {label}
       </AccordionTitle>
-      <AccordionIcon name={icon} />
+      {!otherPanelIsActive &&
+        (iconTooltip ? (
+          <Tooltip {...iconTooltip}>
+            <AccordionIcon name={icon} pointer />
+          </Tooltip>
+        ) : (
+          <AccordionIcon name={icon} />
+        ))}
     </AccordionPanelHeader>
     <AccordionPanelContainer isActive={isActive} contentHeight={contentHeight}>
       <AccordionPanelDetails>{isActive && renderContent()}</AccordionPanelDetails>
@@ -100,6 +119,7 @@ const AccordionPanel = ({
 
 AccordionPanel.defaultProps = {
   icon: '',
+  iconTooltip: null,
 };
 
 export default AccordionPanel;

--- a/src/elements/Accordion/AccordionPanel.js
+++ b/src/elements/Accordion/AccordionPanel.js
@@ -73,7 +73,7 @@ const AccordionPanelDetails = styled.div`
 type Props = {
   label: string,
   isActive: boolean,
-  otherPanelIsActive: boolean,
+  isOtherPanelActive: boolean,
   icon?: string,
   iconTooltip?: TooltipProps,
   contentHeight: string,
@@ -86,7 +86,7 @@ const AccordionPanel = ({
   openPanel,
   label,
   isActive,
-  otherPanelIsActive,
+  isOtherPanelActive,
   icon,
   iconTooltip,
   renderContent,
@@ -102,7 +102,7 @@ const AccordionPanel = ({
       <AccordionTitle variant="h6" isActive={isActive} disabled={disabled}>
         {label}
       </AccordionTitle>
-      {!otherPanelIsActive &&
+      {!isOtherPanelActive &&
         (iconTooltip ? (
           <Tooltip {...iconTooltip}>
             <AccordionIcon name={icon} pointer />

--- a/src/elements/Accordion/Readme.md
+++ b/src/elements/Accordion/Readme.md
@@ -6,8 +6,10 @@ Accordion or expansion panel is a component that generates Accordion component w
 <br/> - `renderContent` (action used to render the content)
 <br/> - `contentHeight` - that determines the height of the wrapper.
 <br/> - `isExtendable` (display arrow and allow the accordion to extend)
+<br/> - `iconTooltip` (optional parameter - a tooltip to display on hovering the icon, see `Tooltip`'s prop list) - default `null`
 <br/> - `width` (optional parameter - sets the width for the Accordion wrapper) - default 100%
 <br/> - `extendWidth` (optional parameter - defines the width the accordion should extend) - default 20%
+<br/> - `disabled` (optional paremeter - a boolean to disable clicking or opening the panel) - default `false`
 
 ```jsx static
 const panels = [

--- a/src/elements/Accordion/Readme.md
+++ b/src/elements/Accordion/Readme.md
@@ -81,8 +81,33 @@ const panels = [
   {
     label: 'Accordion2',
     icon: 'info-circle',
+    iconTooltip: {
+      content: 'This is a disabled panel with optional icon with a tooltip',
+      placement: 'left',
+    },
     renderContent: () => {
       return <h5>Content for the accordionh2</h5>;
+    },
+    renderActionButton: ({ closeAccordion }) => {
+      return (
+        <Button onClick={closeAccordion} size="sm" buttonModifiers={['buttonPrimary']}>
+          Save
+        </Button>
+      )
+    },
+     renderFooterLink: ({ closeAccordion }) => {
+      return (
+        <Button onClick={closeAccordion} style={{border: 'none', background: 'transparent'}} size="sm">
+          Cancel
+        </Button>
+      )
+    },
+    disabled: true,
+  },
+  {
+    label: 'Accordion3',
+    renderContent: () => {
+      return <h5>Content for the accordionh3</h5>;
     },
     renderActionButton: ({ closeAccordion }) => {
       return (

--- a/src/elements/Accordion/index.js
+++ b/src/elements/Accordion/index.js
@@ -2,14 +2,18 @@
 import React, { Component, type Node } from 'react';
 
 // Components
+import { Props as TooltipProps } from 'components/Tooltip';
 import { AccordionWrapper } from './styled';
 import AccordionPanel from './AccordionPanel';
 import AccordionFooter from './AccordionFooter';
 import Arrow from '../../components/NavBar/Arrow';
 
+// Types
 type Panel = {
   label: string,
   icon?: string,
+  iconTooltip?: TooltipProps,
+  disabled?: boolean,
   renderContent: () => any,
   renderActionButton: ({
     closeAccordion: (e?: SyntheticEvent<*>) => void,
@@ -66,20 +70,33 @@ class Accordion extends Component<Props, State> {
       >
         <div>
           {panels.map((panel, index) => {
-            const { icon, label, renderActionButton, renderContent, renderFooterLink } = panel;
+            const {
+              icon,
+              iconTooltip,
+              label,
+              renderActionButton,
+              renderContent,
+              renderFooterLink,
+              disabled,
+            } = panel;
             const { activePanel } = state;
+            const isActive = activePanel === index;
+            const otherPanelIsActive = !isActive && activePanel !== -1;
 
             return (
               <div key={index}>
                 <AccordionPanel
                   key={index}
-                  isActive={activePanel === index}
+                  isActive={isActive}
                   icon={icon}
+                  iconTooltip={iconTooltip}
                   label={label}
                   renderContent={renderContent}
                   openPanel={this.openPanel(index)}
                   closePanel={this.closePanel}
+                  otherPanelIsActive={otherPanelIsActive}
                   contentHeight={contentHeight}
+                  disabled={disabled}
                 />
                 <AccordionFooter
                   isActive={activePanel === index}
@@ -101,6 +118,7 @@ Accordion.defaultProps = {
   width: '100%',
   extendWidth: '20%',
   isExtendable: false,
+  disabled: false,
 };
 
 /** @component */

--- a/src/elements/Accordion/index.js
+++ b/src/elements/Accordion/index.js
@@ -80,7 +80,7 @@ class Accordion extends Component<Props, State> {
             } = panel;
             const { activePanel } = state;
             const isActive = activePanel === index;
-            const otherPanelIsActive = !isActive && activePanel !== -1;
+            const isOtherPanelActive = !isActive && activePanel !== -1;
 
             return (
               <div key={index}>
@@ -93,7 +93,7 @@ class Accordion extends Component<Props, State> {
                   renderContent={renderContent}
                   openPanel={this.openPanel(index)}
                   closePanel={this.closePanel}
-                  otherPanelIsActive={otherPanelIsActive}
+                  isOtherPanelActive={isOtherPanelActive}
                   contentHeight={contentHeight}
                   disabled={disabled}
                 />

--- a/src/elements/Accordion/index.js
+++ b/src/elements/Accordion/index.js
@@ -13,7 +13,6 @@ type Panel = {
   label: string,
   icon?: string,
   iconTooltip?: TooltipProps,
-  disabled?: boolean,
   renderContent: () => any,
   renderActionButton: ({
     closeAccordion: (e?: SyntheticEvent<*>) => void,
@@ -118,7 +117,6 @@ Accordion.defaultProps = {
   width: '100%',
   extendWidth: '20%',
   isExtendable: false,
-  disabled: false,
 };
 
 /** @component */

--- a/src/elements/Accordion/tests/__snapshots__/index.js.snap
+++ b/src/elements/Accordion/tests/__snapshots__/index.js.snap
@@ -50,6 +50,7 @@ exports[`Accordion renders correctly 1`] = `
   width: 100%;
   box-sizing: border-box;
   background: #fff;
+  cursor: pointer;
   border-bottom: 1px solid #F6F8FB;
   display: -webkit-box;
   display: -webkit-flex;
@@ -69,7 +70,6 @@ exports[`Accordion renders correctly 1`] = `
   font-weight: 100;
   color: #44494e;
   margin: 0;
-  cursor: pointer;
   display: inline;
 }
 

--- a/src/elements/Progress/tests/__snapshots__/index.js.snap
+++ b/src/elements/Progress/tests/__snapshots__/index.js.snap
@@ -9,8 +9,8 @@ exports[`Progress renders correctly 1`] = `
   <path
     className="rc-progress-circle-trail"
     d="M 50,50 m 0,-49.5
-     a 49.5,49.5 0 1 1 0,99
-     a 49.5,49.5 0 1 1 0,-99"
+   a 49.5,49.5 0 1 1 0,99
+   a 49.5,49.5 0 1 1 0,-99"
     fillOpacity="0"
     stroke="#d7dde5"
     strokeLinecap="round"
@@ -27,9 +27,10 @@ exports[`Progress renders correctly 1`] = `
   <path
     className="rc-progress-circle-path"
     d="M 50,50 m 0,-49.5
-     a 49.5,49.5 0 1 1 0,99
-     a 49.5,49.5 0 1 1 0,-99"
+   a 49.5,49.5 0 1 1 0,99
+   a 49.5,49.5 0 1 1 0,-99"
     fillOpacity="0"
+    stroke=""
     strokeLinecap="round"
     strokeWidth={0}
     style={

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -276,6 +276,8 @@ export interface ActionButtonRenderProps {
 export interface AccordionPanel {
   label: string;
   icon?: string;
+  iconTooltip?: TooltipProps;
+  disabled?: boolean;
   renderContent: () => ReactNode;
   renderActionButton: (props: ActionButtonRenderProps) => ReactNode;
   renderFooterLink: (props: ActionButtonRenderProps) => ReactNode;


### PR DESCRIPTION
### Fixes

- Add private AccordionPanel prop 'otherPanelIsActive' to prevent icon rendering
  by an inactive AccordionPanel while another AccordionPanel is active

### Change

- Add and implement public AccordionPanel props 'disabled' and 'iconTooltip'

## OVERVIEW

_Give a brief description of what this PR does._

## WHERE SHOULD THE REVIEWER START?

_`/src/elements/Accordion/index.js`_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
