### PR TITLE
Always display TableCell content in single line by handling long content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 =======
 
+# [0.25.2] - 14-08-2019
+
+### Change
+
+- Always display TableCell content in single line by handling long content overflow and wrapping
+
 # [0.25.1] - 01-08-2019
 
 ### Change

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -58,6 +58,9 @@ const TableCell = styled.td`
   text-align: ${ifProp('alignRight', 'right', 'left')};
   font-weight: ${fontWeights('light')};
   word-wrap: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   a {
     color: ${uiColors('text.light')};
@@ -119,6 +122,7 @@ type Column = {
   title: string,
   key: string,
   render: ({ value: string, rowValues: Data }) => Node,
+  style?: Object,
 };
 
 type RowActions<T> =
@@ -282,7 +286,7 @@ class Table<T> extends React.Component<Props<T>, State> {
     return newData.map(row => (
       <TableRow key={row.id} noBottomBorder={!tableButton}>
         {newColumns.map((column, index) => (
-          <TableCell key={index} alignRight={column.key === 'actions'}>
+          <TableCell key={index} alignRight={column.key === 'actions'} style={column.style || {}}>
             {column.render
               ? column.render({ value: row[column.key], rowValues: row })
               : row[column.key]}

--- a/src/components/Table/tests/__snapshots__/index.js.snap
+++ b/src/components/Table/tests/__snapshots__/index.js.snap
@@ -169,6 +169,9 @@ exports[`Table renders correctly 1`] = `
   text-align: left;
   font-weight: 300;
   word-wrap: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .c8 a {
@@ -188,6 +191,9 @@ exports[`Table renders correctly 1`] = `
   text-align: right;
   font-weight: 300;
   word-wrap: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .c9 a {
@@ -276,6 +282,7 @@ exports[`Table renders correctly 1`] = `
     >
       <td
         className="c8"
+        style={Object {}}
       >
         <div
           className="c3 c4"
@@ -293,11 +300,13 @@ exports[`Table renders correctly 1`] = `
       </td>
       <td
         className="c8"
+        style={Object {}}
       >
         Eli
       </td>
       <td
         className="c9"
+        style={Object {}}
       >
         <span
           aria-hidden={true}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -174,6 +174,7 @@ export interface TableColumn<T extends TableRowData> {
   title: string;
   key: string;
   render?: (props: TableColumn$RenderProps<T>) => ReactNode;
+  style?: CSSProperties;
 }
 
 export interface TableRowData extends Object {


### PR DESCRIPTION
## OVERVIEW

TableCell content is alway displayed in single line by handling long content overflow and wrapping.

## WHERE SHOULD THE REVIEWER START?

_`/src/components/Table/index.js`_

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
