### PR TITLE
Fix: Invalid date in day picker

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     }
   },
   "rules": {
+    "react/sort-comp": 0,
     "react/default-props-match-prop-types": 0,
     "react/no-danger": 0,
     "react/prop-types": "warn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [1.0.4] - 22-10-2019
+
+### Fixes
+
+- Fix invalid date in day picker. Create moment from string without specifying the format
+
 # [1.0.3] - 18-10-2019
 
 ### Fixes

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -20,13 +20,13 @@ type State = {
 };
 
 class Navbar extends Component<Props, State> {
-  static MenuItem: Element<typeof MenuItem>;
-
   state = {
     open: false,
   };
 
   toggleOpen = () => this.setState(({ open }) => ({ open: !open }));
+
+  static MenuItem: Element<typeof MenuItem>;
 
   render() {
     const { children, logo, className, style } = this.props;

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -20,13 +20,13 @@ type State = {
 };
 
 class Navbar extends Component<Props, State> {
+  static MenuItem: Element<typeof MenuItem>;
+
   state = {
     open: false,
   };
 
   toggleOpen = () => this.setState(({ open }) => ({ open: !open }));
-
-  static MenuItem: Element<typeof MenuItem>;
 
   render() {
     const { children, logo, className, style } = this.props;

--- a/src/elements/DayPicker/index.js
+++ b/src/elements/DayPicker/index.js
@@ -33,7 +33,7 @@ const DayPicker = ({
       onDateChange={onDateChange}
       onFocusChange={onFocusChange}
       focused={focused}
-      date={typeof date === 'string' ? moment(date, 'MM-DD-YYYY') : date}
+      date={typeof date === 'string' ? moment(date) : date}
       numberOfMonths={numberOfMonths}
     />
   </DayPickerWrapper>


### PR DESCRIPTION
## OVERVIEW

_Fix invalid date in day picker. Create moment from string without specifying the format_

## WHERE SHOULD THE REVIEWER START?

_`/src/elements/DayPicker/index.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
