### PR TITLE
Wrong position of info icon after arrow icon is added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-# [2.0.0-beta.3] - 05-11-2019
+# [2.0.0-beta.4] - 05-11-2019
 
 ### Fix
 
 - Wrong position of info icon after arrow icon is added
 
-# [2.0.0-beta.2] - 05-11-2019
+# [2.0.0-beta.3] - 05-11-2019
 
 ### Change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.0.0-beta.3] - 05-11-2019
+
+### Fix
+
+- Wrong position of info icon after arrow icon is added
+
 # [2.0.0-beta.2] - 05-11-2019
 
 ### Change

--- a/src/elements/Accordion/AccordionPanel.js
+++ b/src/elements/Accordion/AccordionPanel.js
@@ -73,6 +73,12 @@ const AccordionPanelDetails = styled.div`
   height: 100%;
 `;
 
+const AccordionIconHolder = styled.div`
+  display: flex;
+  width: 3rem;
+  justify-content: space-between;
+`;
+
 type Props = {
   label: string,
   isActive: boolean,
@@ -107,15 +113,17 @@ const AccordionPanel = ({
       <AccordionTitle variant="h6" isActive={isActive} disabled={disabled}>
         {label}
       </AccordionTitle>
-      {!isOtherPanelActive &&
-        (iconTooltip ? (
-          <Tooltip {...iconTooltip}>
-            <AccordionIcon name={icon} pointer />
-          </Tooltip>
-        ) : (
-          <AccordionIcon name={icon} />
-        ))}
-      <InPlayerIcon name={isActive ? 'angle-up' : 'angle-down'} />
+      <AccordionIconHolder>
+        {!isOtherPanelActive &&
+          (iconTooltip ? (
+            <Tooltip {...iconTooltip}>
+              <AccordionIcon name={icon} pointer />
+            </Tooltip>
+          ) : (
+            <AccordionIcon name={icon} />
+          ))}
+        <InPlayerIcon name={isActive ? 'angle-up' : 'angle-down'} />
+      </AccordionIconHolder>
     </AccordionPanelHeader>
     <AccordionPanelContainer isActive={isActive} contentHeight={contentHeight}>
       <AccordionPanelDetails>{isActive && renderContent({ closePanel })}</AccordionPanelDetails>


### PR DESCRIPTION
## OVERVIEW

_Wrong position of info icon after arrow icon is added._

## WHERE SHOULD THE REVIEWER START?

_`/src/elements/Accordion/AccordionPanel.js`_

## HOW CAN THIS BE MANUALLY TESTED?

_yarn styleguide_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
