### PR TITLE
fix Table's border-inclusion logic when headerSection option is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.0.0-beta.18] - 20-12-2019
+
+### Fixes
+
+- Table header section did not have border when headerSection was omitted
+- Table headerSection option accepts null as a value
+
 # [2.0.0-beta.17] - 17-12-2019
 
 ### Fixes

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -144,7 +144,7 @@ type TableOptions<T> = {
     action: (selectedItems: Array<T>) => any,
   },
   rowActions: RowActions<T>,
-  headerSection: Node,
+  headerSection?: Node,
 };
 
 type Props<T = Data> = {
@@ -391,7 +391,7 @@ Table.defaultProps = {
       active: false,
     },
     rowActions: [],
-    headerSection: null,
+    headerSection: undefined,
   },
   showLoader: false,
   tableButton: null,

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -320,8 +320,10 @@ class Table<T> extends React.Component<Props<T>, State> {
 
     const columnContent = this.renderColumns(columns);
 
+    const hasHeaderSection = typeof headerSection !== 'undefined';
+
     return (
-      <TableWrapper className={className} style={style} hasHeaderSection={headerSection !== null}>
+      <TableWrapper className={className} style={style} hasHeaderSection={hasHeaderSection}>
         {showLoader ? (
           <LoaderContainer>
             <Loader />

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -204,7 +204,7 @@ export interface TableOptions<T extends TableRowData> {
     action: () => any;
   };
   rowActions: RowActions<T>;
-  headerSection: Node | JSX.Element | null;
+  headerSection?: Node | JSX.Element | null;
 }
 
 export interface TableProps<TableData extends TableRowData = TableRowData> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -204,7 +204,7 @@ export interface TableOptions<T extends TableRowData> {
     action: () => any;
   };
   rowActions: RowActions<T>;
-  headerSection: Node | JSX.Element;
+  headerSection: Node | JSX.Element | null;
 }
 
 export interface TableProps<TableData extends TableRowData = TableRowData> {


### PR DESCRIPTION
## OVERVIEW

Table border was not shown if the `headerOption` was omitted.

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/components/Table/index.js`_
