### PR TITLE
Refactored Preview Templates to inherit container width

### DIFF
--- a/src/previews/Preview2/index.js
+++ b/src/previews/Preview2/index.js
@@ -85,7 +85,7 @@ Preview2.defaultProps = {
   minWidth: '700px',
   minHeight: undefined,
   height: undefined,
-  width: '700px',
+  width: undefined,
   isRestrictedAsset: false,
   handleOpenModal: () => {},
   loginFooterLabel: 'Already have access? Login with your InPlayer account',

--- a/src/previews/Preview3/index.js
+++ b/src/previews/Preview3/index.js
@@ -97,7 +97,7 @@ Preview3.defaultProps = {
   minWidth: '700px',
   minHeight: undefined,
   height: undefined,
-  width: '700px',
+  width: undefined,
   isRestrictedAsset: false,
   handleOpenModal: () => {},
   loginFooterLabel: 'Already have access? Login with your InPlayer account',

--- a/src/previews/Preview4/index.js
+++ b/src/previews/Preview4/index.js
@@ -128,7 +128,7 @@ Preview4.defaultProps = {
   minWidth: '700px',
   minHeight: '390px',
   height: undefined,
-  width: '700px',
+  width: undefined,
   handleOpenModal: () => {},
   isRestrictedAsset: false,
 };

--- a/src/previews/Preview5/index.js
+++ b/src/previews/Preview5/index.js
@@ -91,7 +91,7 @@ Preview5.defaultProps = {
   minWidth: undefined,
   minHeight: '420px',
   height: undefined,
-  width: '700px',
+  width: undefined,
   handleOpenModal: () => {},
   isRestrictedAsset: false,
 };

--- a/src/previews/Preview5/styled.js
+++ b/src/previews/Preview5/styled.js
@@ -14,7 +14,7 @@ import {
 
 export const StyledPreviewBox = styled(PreviewBox)`
   box-sizing: border-box;
-  width: ${({ width }) => width ?? '700px'};
+  width: ${({ width }) => width ?? '100%'};
   height: ${({ height }) => height ?? 'auto'};
   border: none;
   background: transparent;

--- a/src/previews/Preview6/styled.js
+++ b/src/previews/Preview6/styled.js
@@ -7,9 +7,9 @@ import colors from 'config/colors';
 import { PreviewBox, TemplatesButton, ImageHolder } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
-  width: ${({ width }) => width ?? '850px'};
+  width: ${({ width }) => width ?? '100%'};
   height: ${({ height }) => height ?? 'auto'};
-  max-width: ${({ width }) => width ?? '850px'};
+  max-width: ${({ width }) => width ?? '100%'};
   border: 1px solid ${colors.gray};
   padding: 1em;
   overflow: hidden;

--- a/src/previews/components/SharedComponents.js
+++ b/src/previews/components/SharedComponents.js
@@ -119,9 +119,9 @@ export const PreviewFooter = styled.div`
 `;
 
 export const PreviewBox = styled.div`
-  width: ${({ width }) => width ?? '500px'};
+  width: ${({ width }) => width ?? '100%'};
   height: ${({ height }) => height ?? '580px'};
-  max-width: ${({ width }) => (width ? '' : '520px')};
+  max-width: ${({ width }) => (width ? '' : '100%')};
   min-width: ${({ minWidth }) => minWidth};
   min-height: ${({ minHeight }) => minHeight};
   margin: auto;


### PR DESCRIPTION
## OVERVIEW

_Improved Preview Templates to inherit container width._

## WHERE SHOULD THE REVIEWER START?

 `/src/previews`

## HOW CAN THIS BE MANUALLY TESTED?

_List steps to test this locally._

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
