### PR TITLE
Fix variant type bug and imports

### DIFF
--- a/src/elements/Card/Card.tsx
+++ b/src/elements/Card/Card.tsx
@@ -1,8 +1,7 @@
-// @flow
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
-import colors from 'config/colors';
-import { Typography } from 'elements';
+import colors from 'theme/colors';
+import Typography, {TypographyVariant}  from '../../elements/Typography';
 import CardContent from './CardContent';
 
 const CardWrapper = styled.div`
@@ -34,7 +33,7 @@ const CardTitle = styled(Typography)`
 
 interface Props {
   title?: string;
-  titleVariant?: string;
+  titleVariant?: TypographyVariant;
   className?: string;
   children: ReactNode;
   style?: Record<string, any>;

--- a/src/elements/Card/index.ts
+++ b/src/elements/Card/index.ts
@@ -1,3 +1,1 @@
-import Card from './Card';
-
-export default Card;
+export { default as Card } from './Card';

--- a/src/elements/Typography/index.js
+++ b/src/elements/Typography/index.js
@@ -13,7 +13,7 @@ const typographyModifiers = {
   textWarning,
 };
 
-type TypographyVariant = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+export type TypographyVariant = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
 
 const Paragraph = styled.p`
   font-size: ${fontSizes('medium')};
@@ -37,7 +37,7 @@ const Heading = styled.h1`
 `;
 
 export type TypographyProps = {
-  variant: TypographyVariant,
+  variant?: TypographyVariant,
   description?: boolean,
   children: Node,
   /** A className can be passed down for further styling or extending with CSS-in-JS */


### PR DESCRIPTION
## OVERVIEW

Rewrite Card component using TypeScript.

## WHERE SHOULD THE REVIEWER START?

`/src/elements/Card`

## HOW CAN THIS BE MANUALLY TESTED?

- Tested
By creating a new project including only the Card component and all the required dependencies and imports

## ANY NEW DEPENDENCIES ADDED?

No.

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_
