### PR TITLE
Add fix min-width for all preview boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.0.0-beta.41] - 16-04-2020
+
+### Change
+
+- Add fix min-width for all preview boxes
+
 # [2.0.0-beta.40] - 09-04-2020
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-# [2.0.0-beta.39] - 09-04-2020
+# [2.0.0-beta.40] - 09-04-2020
 
 ### Change
 

--- a/src/previews/Preview1/styled.js
+++ b/src/previews/Preview1/styled.js
@@ -19,7 +19,7 @@ import {
 } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
-  height: ${({ height }) => height ?? 'auto'};
+  max-width: ${({ width }) => (width ? '' : '70vh')};
   border-radius: 8px 8px 3px 3px;
 `;
 

--- a/src/previews/Preview2/styled.js
+++ b/src/previews/Preview2/styled.js
@@ -16,8 +16,8 @@ import {
 } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
+  max-width: ${({ width }) => (width ? '' : '70vh')};
   font-size: ${fontSizes('large')};
-  height: ${({ height }) => height ?? 'auto'};
   overflow: hidden;
   border-radius: 8px 8px 3px 3px;
 `;

--- a/src/previews/Preview3/index.js
+++ b/src/previews/Preview3/index.js
@@ -58,7 +58,7 @@ const Preview3 = ({
     <StyledPreviewBox
       minHeight={minHeight}
       minWidth={minWidth}
-      color={previewTopBorder ? buttonBgColor : colors.white}
+      color={previewTopBorder ? buttonBgColor : ''}
       width={width}
       height={height}
     >

--- a/src/previews/Preview3/styled.js
+++ b/src/previews/Preview3/styled.js
@@ -17,8 +17,8 @@ import {
 } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
-  height: ${({ height }) => height ?? 'auto'};
-  border-top: 3px solid ${({ color }) => color};
+  max-width: ${({ width }) => (width ? '' : '70vh')};
+  ${({ color }) => color && `border-top: 3px solid ${color}`};
   display: block;
   padding: 1% 3% 2% 3%;
   color: ${colors.fontDarkGray};

--- a/src/previews/Preview3/styled.js
+++ b/src/previews/Preview3/styled.js
@@ -75,6 +75,7 @@ export const TitleBorder = styled.div`
 export const StyledIcon = styled(FaRegPlayCircle)`
   font-size: ${fontSizes('extraLarge')};
   color: ${({ color }) => color};
+  cursor: pointer;
 
   :hover {
     outline: none;

--- a/src/previews/Preview4/index.js
+++ b/src/previews/Preview4/index.js
@@ -67,7 +67,7 @@ const Preview4 = ({
     <StyledPreviewBox
       minWidth={minWidth}
       minHeight={minHeight}
-      topBorderColor={previewTopBorder ? buttonBgColor : colors.white}
+      topBorderColor={previewTopBorder ? buttonBgColor : ''}
       width={width}
       height={height}
     >

--- a/src/previews/Preview4/styled.js
+++ b/src/previews/Preview4/styled.js
@@ -16,9 +16,9 @@ import {
 } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
-  height: ${({ height }) => height ?? 'auto'};
+  max-width: ${({ width }) => (width ? '' : '70vh')};
   overflow: hidden;
-  border-top: 4px solid ${({ topBorderColor }) => topBorderColor};
+  ${({ topBorderColor }) => topBorderColor && `border-top: 4px solid ${topBorderColor}`};
   display: flex;
   flex-direction: column-reverse;
   border-radius: 3px 3px 0 0;

--- a/src/previews/Preview5/styled.js
+++ b/src/previews/Preview5/styled.js
@@ -16,7 +16,7 @@ import {
 } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
-  height: ${({ height }) => height ?? 'auto'};
+  max-width: ${({ width }) => (width ? '' : '60vh')};
   border: none;
   background: transparent;
   font-size: ${fontSizes('medium')};

--- a/src/previews/Preview6/styled.js
+++ b/src/previews/Preview6/styled.js
@@ -8,7 +8,7 @@ import { fontSizes } from 'utils/index';
 import { PreviewBox, ImageHolder } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
-  height: ${({ height }) => height ?? 'auto'};
+  max-width: ${({ width }) => (width ? '' : '850px')};
   padding: 1em;
   overflow: hidden;
   border-radius: 8px 8px 3px 3px;
@@ -70,7 +70,7 @@ export const PreviewFooter = styled.div`
   float: right;
   width: 50%;
   text-align: right;
-  padding-top: 0.8em;
+  padding-top: 2em;
 `;
 
 export const IconHolder = styled.div`

--- a/src/previews/Preview7/styled.js
+++ b/src/previews/Preview7/styled.js
@@ -16,8 +16,8 @@ import {
 } from '../components/SharedComponents';
 
 export const StyledPreviewBox = styled(PreviewBox)`
+  max-width: ${({ width }) => (width ? '' : '500px')};
   border-radius: 8px 8px 3px 3px;
-  height: ${({ height }) => height ?? 'auto'};
   display: flex;
   flex-direction: column;
 `;

--- a/src/previews/components/SharedComponents.js
+++ b/src/previews/components/SharedComponents.js
@@ -12,8 +12,7 @@ import { Typography, Button } from 'elements';
 
 export const PreviewBox = styled.div`
   width: ${({ width }) => width ?? '100%'};
-  height: ${({ height }) => height ?? '580px'};
-  max-width: ${({ width }) => (width ? '' : '100%')};
+  height: ${({ height }) => height ?? 'auto'};
   min-width: ${({ minWidth }) => minWidth};
   min-height: ${({ minHeight }) => minHeight};
   margin: auto;


### PR DESCRIPTION
## OVERVIEW

_Add fix min-width for all preview boxes. Change border top color for preview3 and preview4_

## WHERE SHOULD THE REVIEWER START?

` src/previews/`

## HOW CAN THIS BE MANUALLY TESTED?

_List steps to test this locally._

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
