### PR TITLE
fix: remove polished normalize func from GlobalStyles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.4.2] - 11-11-2020
+
+### Fixes
+
+- Remove polished normalize function from GlobalStyles
+
 # [2.4.1] - 21-09-2020
 
 ### Changes

--- a/src/theme/globalStyles.ts
+++ b/src/theme/globalStyles.ts
@@ -1,10 +1,7 @@
 import { createGlobalStyle } from 'styled-components';
-import { normalize } from 'polished';
 
 // Global styles but theme- and update-able!
 const GlobalStyle = createGlobalStyle`
-  ${normalize()}
-
   html,
   body {
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## OVERVIEW

_Remove polished normalize function from GlobalStyles._

## WHERE SHOULD THE REVIEWER START?

_`/src/theme/GlobalStyles.ts`_

## ANY NEW DEPENDENCIES ADDED?

_None._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
