### PR TITLE
Changed width, height and padding-left of Checkbox component's top wr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.5.6] - 09-04-2021
+
+### Fixes
+
+- Changed width, height and padding-left of Checkbox component's top wrapper to be in `em` instead of `rem`
+
 # [2.5.5] - 22-03-2021
 
 ### Change
@@ -19,7 +25,7 @@ All notable changes to this project will be documented in this file.
 ### Change
 
 - Add missing className for Switch component in order to externaly style it with styled-components
-  
+
 ### Fixes
 
 - Daypicker moment type error

--- a/src/components/Checkbox/CheckboxWrapper.ts
+++ b/src/components/Checkbox/CheckboxWrapper.ts
@@ -10,7 +10,7 @@ const CheckboxWrapper = styled.div<{ theme: DefaultTheme }>`
 
   > input + label {
     position: relative;
-    padding-left: 1.5rem;
+    padding-left: 1.5em;
     cursor: pointer;
 
     &::before {
@@ -18,8 +18,8 @@ const CheckboxWrapper = styled.div<{ theme: DefaultTheme }>`
       position: absolute;
       left: 0;
       top: 0;
-      width: 1rem;
-      height: 1rem;
+      width: 1em;
+      height: 1em;
       border: 1px solid ${colors.gray};
       background: ${colors.white};
       border-radius: 2px;
@@ -44,8 +44,8 @@ const CheckboxWrapper = styled.div<{ theme: DefaultTheme }>`
       border: 2px solid ${colors.skyBlue};
       border-top: none;
       border-right: none;
-      width: 0.5rem;
-      height: 0.25rem;
+      width: 0.5em;
+      height: 0.25em;
       opacity: 1;
       transform: scale(1) rotate(-45deg);
     }
@@ -56,8 +56,8 @@ const CheckboxWrapper = styled.div<{ theme: DefaultTheme }>`
       border: 2px solid ${colors.white};
       border-top: none;
       border-right: none;
-      width: 0.5rem;
-      height: 0.25rem;
+      width: 0.5em;
+      height: 0.25em;
       opacity: 1;
       transform: scale(0);
     }


### PR DESCRIPTION
Changed width, height and padding-left of Checkbox component's top wrapper to be in `em` instead of `rem`

## OVERVIEW

_Give a brief description of what this PR does._

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/components/Checkbox/CheckboxWrapper.ts`_

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_In Paywall:._
![image](https://user-images.githubusercontent.com/46674160/114149256-01e6c600-991b-11eb-9fc4-e1b7c5031a27.png)

_In Dashboard:_
![image](https://user-images.githubusercontent.com/46674160/114153306-7b80b300-991f-11eb-886f-8eed62daadd4.png)

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest `dev`
