### PR TITLE
feat: Add basic analytics types and components

### DIFF
--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -1,0 +1,75 @@
+export type AnalyticsTag = string;
+
+/**
+ * Props present on various components which aid in the tracking of analytics events.
+ */
+export interface AnalyticsProps {
+  /** Unique identifier of the component within the logical page hierarchy. */
+  tag: AnalyticsTag;
+
+  /** Posiition of the component within a table-like component. */
+  position?: {
+    /** Unique ID of the row (usually what you would use as a key in react). */
+    id: string;
+
+    /** Row index. */
+    row?: number;
+
+    /** Column index or name. */
+    column?: number | string;
+  };
+}
+
+/** Receives tracking events and dispatches them to handlers. */
+export class AnalyticsTracker {}
+
+export type AnalyticsPageType = 'page' | 'modal' | 'tab';
+
+export interface AnalyticsPage {
+  tag: AnalyticsTag;
+  type: AnalyticsPageType;
+}
+
+export interface AnalyticsContextValue {
+  pages: AnalyticsPage[];
+  tracker: AnalyticsTracker;
+}
+
+export const ROOT_ANALYTICS_CONTEXT: AnalyticsContextValue = {
+  pages: [],
+  tracker: new AnalyticsTracker(),
+};
+
+/** React context you can use to access the current tracker and page hierarchy. */
+export const AnalyticsContext = React.createContext(ROOT_ANALYTICS_CONTEXT);
+
+export type AnalyticsPageProps = {
+  /** Tag of this page. */
+  tag: AnalyticsTag;
+
+  /** Type of this page. */
+  type: AnalyticsPageType;
+
+  /** Children in the page. */
+  children?: React.ReactNode;
+};
+
+export type AnalyticsComponentProps = {
+  children?: (context: AnalyticsContextValue) => React.ReactNode;
+};
+
+/** A component to wrap other components with to gain access to the AnalyticsContextValue. */
+export const AnalyticsComponent = ({ children }: AnalyticsComponentProps) => (
+  <AnalyticsContext.Consumer>{children}</AnalyticsContext.Consumer>
+);
+
+/** Registers a subpage in the analytics component hierarchy. */
+export const AnalyticsPage = ({ tag, type, children }: AnalyticsPageProps) => (
+  <AnalyticsContext.Consumer>
+    {({ pages, tracker }) => (
+      <AnalyticsContext.Provider value={{ pages: [...pages, { tag, type }], tracker }}>
+        {children}
+      </AnalyticsContext.Provider>
+    )}
+  </AnalyticsContext.Consumer>
+);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React, { ButtonHTMLAttributes, ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 import ButtonWrapper from './ButtonWrapper';
+import { AnalyticsProps } from '../../analytics';
 
 export type Size = 'xs' | 'sm' | 'md' | 'lg';
 
@@ -17,7 +18,7 @@ export type Props = ButtonHTMLAttributes<HTMLButtonElement> &
     className?: string;
     fullWidth?: boolean;
     fullHeight?: boolean;
-  };
+  } & AnalyticsProps;
 
 const ContentHolder = styled.span`
   margin-top: 2px;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -4,6 +4,7 @@ import { transparentize } from 'polished';
 import colors from '../../theme/colors';
 import Typography, { TypographyVariant } from '../Typography/Typography';
 import CardContent from './CardContent';
+import { AnalyticsProps } from '../../analytics';
 
 const CardWrapper = styled.div`
   display: flex;
@@ -32,12 +33,12 @@ const CardTitle = styled(Typography)`
   display: inline-block;
 `;
 
-interface Props {
+type Props = {
   title?: string;
   titleVariant?: TypographyVariant;
   className?: string;
   children: ReactChild;
-}
+} & AnalyticsProps;
 
 const Card = ({ title, titleVariant = 'h1', className = '', children }: Props) => (
   <CardWrapper className={className}>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, RefObject } from 'react';
 import Label from '../Label';
 import CheckboxWrapper from './CheckboxWrapper';
+import { AnalyticsProps } from '../../analytics';
 
 type Props = {
   label: string;
@@ -10,7 +11,7 @@ type Props = {
   onChange: (checked: boolean) => any;
   containerRef?: RefObject<HTMLDivElement> | null;
   disabled?: boolean;
-};
+} & AnalyticsProps;
 
 const Checkbox: React.FC<Props> = ({
   label,

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -10,6 +10,7 @@ import { Option } from '../Dropdown/Dropdown';
 import DatePickerWrapper from './DatePickerWrapper';
 import { PERIODS, INNERPERIODS } from './periods';
 import { Styled } from './styles';
+import { AnalyticsProps } from '../../analytics';
 import 'react-dates/initialize';
 
 const ContentHolder = styled.div<{ isDropdown?: boolean }>`
@@ -99,7 +100,7 @@ type Props = {
   showInnerPresets?: boolean;
   className?: string;
   showPresetsWithDropdown?: boolean;
-};
+} & AnalyticsProps;
 
 const DatePicker = ({
   activePeriodPreset = '',

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import DayPickerWrapper from './DayPickerWrapper';
 import Dropdown from '../Dropdown';
 import { getMonthOptions, getYearOptions } from '../../utils/helpers';
+import { AnalyticsProps } from '../../analytics';
 
 const CustomMonthContainer = styled.div`
   display: flex;
@@ -36,7 +37,7 @@ type Props = {
   placeholder?: string;
   onClose?: () => any;
   disablePastDays?: boolean;
-};
+} & AnalyticsProps;
 
 const DayPicker = ({
   isOutsideRange = () => false,

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import DrawerContainer from './DrawerContainer';
+import { AnalyticsProps } from '../../analytics';
 
-interface Props {
+type Props = {
   handleClose: () => void;
   isOpen: boolean;
   width?: string;
-}
+} & AnalyticsProps;
 
 const Drawer: React.FC<Props> = ({ children, handleClose, isOpen, width = '40%' }) => (
   <DrawerContainer shouldShowDrawer={isOpen} closeDrawer={handleClose} width={width}>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,15 +1,16 @@
 import React, { SelectHTMLAttributes, ChangeEvent } from 'react';
 import DropdownContainer from './DropdownContainer';
+import { AnalyticsProps } from '../../analytics';
 
 export type Option = {
   value: string;
   displayName: string;
-};
+} & AnalyticsProps;
 
 type DefaultOption = {
   displayName: string;
   disabled?: boolean;
-};
+} & AnalyticsProps;
 
 type SelectHTMLProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'onChange'>;
 
@@ -22,7 +23,7 @@ type Props = SelectHTMLProps & {
   disabled?: boolean;
   defaultOption?: DefaultOption;
   className?: string;
-};
+} & AnalyticsProps;
 
 const Dropdown: React.FC<Props> = ({
   options,

--- a/src/components/Grid/Cell.ts
+++ b/src/components/Grid/Cell.ts
@@ -1,4 +1,5 @@
 import styled, { CSSProperties } from 'styled-components';
+import { AnalyticsProps } from '../../analytics';
 
 type CellProps = {
   width?: CSSProperties;
@@ -8,7 +9,7 @@ type CellProps = {
   center?: CSSProperties;
   area?: CSSProperties;
   middle?: CSSProperties;
-};
+} & AnalyticsProps;
 
 const Cell = styled.div<CellProps>`
   height: 100%;

--- a/src/components/Grid/Container.ts
+++ b/src/components/Grid/Container.ts
@@ -1,4 +1,5 @@
 import styled, { CSSProperties, CSSObject } from 'styled-components';
+import { AnalyticsProps } from '../../analytics';
 
 const autoRows = ({ minRowHeight = '20px' }) => `minmax(${minRowHeight}, auto)`;
 
@@ -18,7 +19,7 @@ type GridContainerProps = {
   areas?: any;
   justifyContent?: CSSProperties;
   alignContent?: CSSProperties;
-};
+} & AnalyticsProps;
 
 const GridContainer = styled.div<GridContainerProps>`
   display: grid;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import { ifProp, switchProp } from 'styled-tools';
 import { MdSearch } from 'react-icons/md';
 import colors from '../../theme/colors';
+import { AnalyticsProps } from '../../analytics';
 
 type Size = 'xs' | 'sm' | 'md' | 'lg';
 
@@ -84,7 +85,7 @@ type Props = {
   sizeProp?: Size;
   icon?: ReactNode;
   className?: string;
-};
+} & AnalyticsProps;
 
 type RefType =
   | ((instance: HTMLInputElement | null) => void)

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 import { ifProp } from 'styled-tools';
 import { applyStyleModifiers } from 'styled-components-modifiers';
 import { fontSizeExtraSmall, fontSizeSmall, fontSizeMedium, fontSizeLarge } from '../../modifiers';
+import { AnalyticsProps } from '../../analytics';
 
 const typographyModifiers = {
   fontSizeExtraSmall,
@@ -10,7 +11,7 @@ const typographyModifiers = {
   fontSizeLarge,
 };
 
-const Label = styled.label<{ disabled?: boolean }>`
+const Label = styled.label<{ disabled?: boolean } & AnalyticsProps>`
   font-size: ${({ theme }) => theme.font.sizes.medium};
   font-weight: ${({ theme }) => theme.font.weights.normal};
   color: ${({ theme }) => theme.palette.text.main};

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
 import colors from '../../theme/colors';
+import { AnalyticsProps } from '../../analytics';
 
 const directions: Record<string, any> = {
   up: '16,0 32,32 0,32',
@@ -33,7 +34,7 @@ type Props = {
   color?: string;
   lineWidth?: number;
   direction?: string;
-};
+} & AnalyticsProps;
 
 const Loader = ({
   height = 100,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -6,6 +6,7 @@ import { transparentize } from 'polished';
 import colors from '../../theme/colors';
 import ModalHeader from './ModalHeader';
 import ModalContent from './ModalContent';
+import { AnalyticsProps, AnalyticsPage } from '../../analytics';
 
 interface ModalWrapperProps {
   isOpen: boolean;
@@ -40,9 +41,10 @@ type Props = {
   isOverflowVisible?: boolean;
   className?: string;
   children: ReactChild;
-};
+} & AnalyticsProps;
 
 const Modal = ({
+  tag,
   isOverflowVisible = false,
   isModalOpen,
   closeModal,
@@ -50,16 +52,18 @@ const Modal = ({
   title,
   className = '',
 }: Props) => (
-  <ModalWrapper
-    className={className}
-    isOpen={isModalOpen}
-    onClick={isModalOpen ? closeModal : undefined}
-  >
-    <ModalContainer isOverflowVisible={isOverflowVisible} onClick={(e) => e.stopPropagation()}>
-      <ModalHeader closeModal={closeModal}>{title}</ModalHeader>
-      <ModalContent>{children}</ModalContent>
-    </ModalContainer>
-  </ModalWrapper>
+  <AnalyticsPage tag={tag} type="modal">
+    <ModalWrapper
+      className={className}
+      isOpen={isModalOpen}
+      onClick={isModalOpen ? closeModal : undefined}
+    >
+      <ModalContainer isOverflowVisible={isOverflowVisible} onClick={(e) => e.stopPropagation()}>
+        <ModalHeader closeModal={closeModal}>{title}</ModalHeader>
+        <ModalContent>{children}</ModalContent>
+      </ModalContainer>
+    </ModalWrapper>
+  </AnalyticsPage>
 );
 
 export default Modal;

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -4,14 +4,15 @@ import { MdInfoOutline, MdWarning } from 'react-icons/md';
 import { IoIosCheckmarkCircle } from 'react-icons/io';
 
 import colors from '../../theme/colors';
+import { AnalyticsProps } from '../../analytics';
 
 import NoteWrapper, { NoteType } from './NoteWrapper';
 
-interface Props {
+type Props = {
   title: string;
   text: string;
   type: NoteType;
-}
+} & AnalyticsProps;
 
 interface IconProps {
   color?: string;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import NotificationContainer, { CloseIcon } from './NotificationContainer';
+import { AnalyticsProps } from '../../analytics';
 
 export type NotificationVariant = 'success' | 'danger' | 'warning' | '';
 
@@ -10,7 +11,7 @@ type Props = {
   variant?: NotificationVariant;
   duration?: number;
   close?: () => void;
-};
+} & AnalyticsProps;
 
 const divs: Array<HTMLDivElement> = [];
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { FaAngleDoubleLeft, FaAngleDoubleRight, FaAngleLeft, FaAngleRight } from 'react-icons/fa';
 import { PageBox, PaginationContainer } from './styled';
+import { AnalyticsProps } from '../../analytics';
 
 type PaginationProps = {
   onPageChange: (pageNumber: number) => void;
@@ -8,7 +9,7 @@ type PaginationProps = {
   startPage?: number;
   numberOfPagesDisplayed?: number;
   itemsPerPage?: number;
-};
+} & AnalyticsProps;
 
 // Kibana has limit of 10000 items
 const itemsLimit = 10000;

--- a/src/components/Pagination/styled.ts
+++ b/src/components/Pagination/styled.ts
@@ -30,18 +30,18 @@ const getBoxStyles = ({
     `;
   }
   return css`
-  :hover {
-    border: 1px solid ${colors.skyBlue};
-    ${ifProp(
-      'hideBorder',
-      css`
-        border: none;
-      `
-    )}
-    color: ${colors.skyBlue};
-    font-weight: bold;
-  }
-`;
+    :hover {
+      border: 1px solid ${colors.skyBlue};
+      ${ifProp(
+        'hideBorder',
+        css`
+          border: none;
+        `
+      )}
+      color: ${colors.skyBlue};
+      font-weight: bold;
+    }
+  `;
 };
 
 export const PageBox = styled.button`

--- a/src/components/PillLabel/PillLabel.ts
+++ b/src/components/PillLabel/PillLabel.ts
@@ -3,6 +3,7 @@ import { applyStyleModifiers } from 'styled-components-modifiers';
 import { transparentize } from 'polished';
 import { switchProp } from 'styled-tools';
 import colors from '../../theme/colors';
+import { AnalyticsProps } from '../../analytics';
 
 const modifiers = {
   primary: () => `
@@ -32,7 +33,7 @@ const modifiers = {
   `,
 };
 
-const PillLabel = styled.span<{ size?: string; modifiers?: Array<string> }>`
+const PillLabel = styled.span<{ size?: string; modifiers?: Array<string> } & AnalyticsProps>`
   display: inline-block;
   background: ${colors.white};
   color: ${({ theme }) => theme.palette.text.main};

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Line, Circle } from 'rc-progress';
+import { AnalyticsProps } from '../../analytics';
 
 type ProgressType = 'circle' | 'line';
 
@@ -19,7 +20,7 @@ type RCProgressProps = {
   gapPosition?: 'top' | 'right' | 'bottom' | 'left';
 };
 
-type Props = Type & RCProgressProps;
+type Props = Type & RCProgressProps & AnalyticsProps;
 
 const Progress = ({ type, ...rest }: Props) =>
   type === 'circle' ? <Circle {...rest} /> : <Line {...rest} />;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, InputHTMLAttributes } from 'react';
 import { StyledLabel, Root, Input, Fill } from './RadioWrapper';
+import { AnalyticsProps } from '../../analytics';
 
 type RadioProps = InputHTMLAttributes<HTMLInputElement> & {
   label: string;
@@ -9,7 +10,7 @@ type RadioProps = InputHTMLAttributes<HTMLInputElement> & {
   onChange: (e: ChangeEvent<HTMLInputElement>) => any;
   onBlur?: (e: any) => any;
   disabled?: boolean;
-};
+} & AnalyticsProps;
 
 const Radio = ({
   label,

--- a/src/components/StepWizard/Nav.tsx
+++ b/src/components/StepWizard/Nav.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { ifProp } from 'styled-tools';
 
+import { AnalyticsProps } from '../../analytics';
 import colors from '../../theme/colors';
 
 const StepNavigation = styled.div`
@@ -50,13 +51,13 @@ export type StepItem = {
   isDisabled: boolean;
   isCompleted: boolean;
   component: React.ReactChild;
-};
+} & AnalyticsProps;
 
 type Props = {
   steps: Array<StepItem>;
   activeStep: number;
   goToStep: (activeStep: number) => void;
-};
+} & AnalyticsProps;
 
 const Nav = ({ steps, goToStep, activeStep }: Props) => (
   <StepNavigation>

--- a/src/components/StepWizard/StepWizard.tsx
+++ b/src/components/StepWizard/StepWizard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Nav, { StepItem } from './Nav';
 import Step from './Step';
+import { AnalyticsProps } from '../../analytics';
 
 type TransitionVariant = 'fadeInLeft' | 'fadeInRight' | 'fadeOutLeft' | 'fadeOutRight';
 
@@ -9,7 +10,7 @@ type StepWizardProps = {
   activeStep: number;
   onStepChange?: (activeStep: number) => void;
   transition?: TransitionVariant;
-};
+} & AnalyticsProps;
 
 const StepWizard = ({
   steps,

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import colors from '../../theme/colors';
 import SwitchWrapper from './SwitchWrapper';
 import Label from '../Label';
+import { AnalyticsProps } from '../../analytics';
 
 type SwitchProps = {
   checked: boolean;
@@ -11,7 +12,7 @@ type SwitchProps = {
   label: string;
   onChange: (checked: boolean) => void;
   className?: string;
-};
+} & AnalyticsProps;
 
 const MarginLeftLabel = styled(Label)`
   margin-right: 0.5rem;

--- a/src/components/TabNavigation/TabNavigation.tsx
+++ b/src/components/TabNavigation/TabNavigation.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 import { ifProp } from 'styled-tools';
+import { AnalyticsProps } from '../../analytics';
 
 const Tab = styled.a<{ active: boolean }>`
   height: 100%;
@@ -39,20 +40,20 @@ const TabContainer = styled.div`
 
 type NavigationTab = {
   title: string;
-};
+} & AnalyticsProps;
 
 export type Props = {
   tabs: Array<NavigationTab>;
   onTabClick: (index: number) => void;
   selectedTabIndex: number;
-};
+} & AnalyticsProps;
 
 const TabNavigation = ({ tabs, onTabClick, selectedTabIndex }: Props) => (
   <TabContainer>
     {tabs.map((tab, index) => (
       <Tab
-        id={tab.title.toLowerCase()}
         key={tab.title}
+        id={tab.title.toLowerCase()}
         onClick={() => onTabClick(index)}
         active={selectedTabIndex === index}
       >

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode, SyntheticEvent, Component } from 'react';
 import { CSSProperties } from 'styled-components';
 import Grid from '../Grid';
 import Loader from '../Loader';
+import { AnalyticsProps } from '../../analytics';
 import {
   ButtonTableRow,
   LoaderContainer,
@@ -69,7 +70,7 @@ type Props<T = Data> = {
   renderEmptyTable?: boolean;
   tableButton?: Array<TableButtonProps>;
   actionsRowTitle?: string;
-};
+} & AnalyticsProps;
 
 type State = {
   selected: {

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -1,9 +1,10 @@
 import styled, { css } from 'styled-components';
 import { ifProp } from 'styled-tools';
 
+import { AnalyticsProps } from '../../analytics';
 import colors from '../../theme/colors';
 
-const Tab = styled.div<{ selected: boolean }>`
+const TabWrapper = styled.div<{ selected: boolean }>`
   margin: 0;
   padding: 0.5rem 0;
   display: flex;
@@ -41,5 +42,11 @@ const Tab = styled.div<{ selected: boolean }>`
     `
   )};
 `;
+
+export type Props = {
+  selected: boolean;
+} & AnalyticsProps;
+
+const Tab = ({ tag, ...rest }: Props) => <TabWrapper {...rest} />
 
 export default Tab;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,7 @@
 import React, { HTMLAttributes, ReactElement } from 'react';
 import Tab from './Tab';
 import TabsWrapper from './TabsWrapper';
+import { AnalyticsProps } from '../../analytics';
 
 interface TabInfo {
   name: string;
@@ -16,7 +17,7 @@ type TabsProps = HTMLAttributes<HTMLDivElement> &
     tabs: Array<TabInfo>;
     selectedTabIndex: number;
     onTabClick: (index: number) => void;
-  };
+  } & AnalyticsProps;
 
 const Content = ({ icon = null, iconPosition = 'left', name }: ContentProps) =>
   iconPosition === 'right' ? (

--- a/src/components/TextArea/TextArea.ts
+++ b/src/components/TextArea/TextArea.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
+import { AnalyticsProps } from '../../analytics';
 import colors from '../../theme/colors';
 
-const TextArea = styled.textarea`
+const TextArea = styled.textarea<AnalyticsProps>`
   vertical-align: middle;
   box-sizing: border-box;
   overflow: hidden;

--- a/src/components/Tooltip/Arrow.tsx
+++ b/src/components/Tooltip/Arrow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { AnalyticsProps } from '../../analytics';
 
 type ArrowsProps = {
   width: number;
@@ -59,7 +60,7 @@ type Props = {
   border: string;
   placement: string;
   width: number;
-};
+} & AnalyticsProps;
 
 const Arrow = ({ background, border, placement, width }: Props) => {
   const Component = arrows[placement] || arrows.top;

--- a/src/components/Tooltip/Bubble.ts
+++ b/src/components/Tooltip/Bubble.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import colors from '../../theme/colors';
+import { AnalyticsProps } from '../../analytics';
 
 type BubbleProps = {
   background?: string;
@@ -7,7 +8,7 @@ type BubbleProps = {
   border?: string;
   padding?: number;
   fontSize?: string;
-};
+} & AnalyticsProps;
 
 const Bubble = styled.div<BubbleProps>`
   color: ${colors.white};

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import Arrow from './Arrow';
 import TooltipWrapper, { FadeEasing } from './TooltipWrapper';
 import Bubble from './Bubble';
+import { AnalyticsProps } from '../../analytics';
 
 export interface FlashTooltipRef {
   flashTooltip: () => Promise<void>;
@@ -38,7 +39,7 @@ export type TooltipProps = {
   className?: string;
   children?: ReactChild | ReactNode | null;
   ref: Ref<FlashTooltipRef>;
-};
+} & AnalyticsProps;
 
 const Container = styled.div`
   position: relative;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,3 +42,6 @@ export { default as ThemeWrapper } from './theme/ThemeWrapper';
 
 // colors
 export { default as Colors } from './theme/colors';
+
+// analytics
+export * from './analytics';


### PR DESCRIPTION
## OVERVIEW

In order to support tracking analytics events when using this library, we're adding some non-mandatory `AnalyticsProps` to all relevant components.

Additionally, we're adding the skeleton of the analytics tracking architecture with the `AnalyticsPage`, `AnalyticsComponent`, `AnalyticsTracker` to unblock dependents on this library.

## WHERE SHOULD THE REVIEWER START?

`/src/analytics/index.tsx`

## HOW CAN THIS BE MANUALLY TESTED?

This practically does not change anything at runtime -- mostly adds types.


## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
