### PR TITLE
Add explicit exports from analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.5.12] - 28-09-2021
+
+## Added
+
+- Explicit exports for components, types and interfaces from `src/analytics`.
+
 # [2.5.11] - 28-09-2021
 
 ## Added

--- a/src/analytics/index.tsx
+++ b/src/analytics/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 export type AnalyticsTag = string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,14 +44,17 @@ export { default as ThemeWrapper } from './theme/ThemeWrapper';
 export { default as Colors } from './theme/colors';
 
 // analytics
-export {
-  AnalyticsPage,
+export type {
   AnalyticsProps,
   AnalyticsPageProps,
-  AnalyticsContext,
-  AnalyticsTracker,
   AnalyticsPageType,
   AnalyticsTag,
-  AnalyticsContextValue,
-  AnalyticsComponent,
+  AnalyticsContextValue
+} from './analytics';
+
+export {
+  AnalyticsPage,
+  AnalyticsContext,
+  AnalyticsTracker,
+  AnalyticsComponent
 } from './analytics';

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,4 +44,14 @@ export { default as ThemeWrapper } from './theme/ThemeWrapper';
 export { default as Colors } from './theme/colors';
 
 // analytics
-export * from './analytics';
+export {
+  AnalyticsPage,
+  AnalyticsProps,
+  AnalyticsPageProps,
+  AnalyticsContext,
+  AnalyticsTracker,
+  AnalyticsPageType,
+  AnalyticsTag,
+  AnalyticsContextValue,
+  AnalyticsComponent,
+} from './analytics';


### PR DESCRIPTION
## OVERVIEW

Explicitly exports values and types from `src/analytics`.

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
