### PR TITLE
Preview footer color change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.5.27] - 04.08.2022
+
+## Added
+
+- Changed the color of the text in the footer for Previews from fixed value to a value from the theme colors
+
 # [2.5.26] - 21.07.2022
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inplayer-org/inplayer-ui",
   "sideEffects": false,
-  "version": "2.5.26",
+  "version": "2.5.27",
   "author": "InPlayer",
   "description": "InPlayer React UI Components",
   "main": "dist/inplayer-ui.cjs.js",

--- a/src/paywall-previews/Preview1/styled.ts
+++ b/src/paywall-previews/Preview1/styled.ts
@@ -3,7 +3,6 @@ import { ifProp } from 'styled-tools';
 import { transparentize } from 'polished';
 import { FaLock } from 'react-icons/fa';
 import colors from '../../theme/colors';
-import { RestrictedAssetContainer } from '../shared/PreviewComponents';
 
 export const InPlayerPreviewBox = styled.div`
   background: ${({ theme }) => theme.palette.background.main};
@@ -195,7 +194,7 @@ export const InplayerFooter = styled.div`
 
   a {
     text-decoration: none;
-    color: #aaa;
+    color: ${({ theme }) => theme.palette.text.light};
     font-size: 14px;
     line-height: 18px;
   }


### PR DESCRIPTION
## OVERVIEW

The color of the footer in the previews is now based on the theme and not a fixed value. This was requested due to bad visibility. More info can be found in the notion card.

Notion card: [Login CTA Visibility in Paywall Preview`](https://www.notion.so/5010c87fccf5479e946ea7750c549dfe?v=1bc672978c16425c927a0427ed33ef39&p=dfdea3f097ea4e65b2da2dd41043c915&pm=s)

## WHERE SHOULD THE REVIEWER START?

src/paywall-previews/Preview1/styled.ts

## HOW CAN THIS BE MANUALLY TESTED?

_List steps to test this locally._

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

_Does your change affect the UI? If so, please add a screenshot._

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify the linters and tests pass: `yarn review`
- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
